### PR TITLE
Names with spaces need to be formatted for entity IDs

### DIFF
--- a/python_scripts/bhyve_next_watering.py
+++ b/python_scripts/bhyve_next_watering.py
@@ -9,12 +9,12 @@ zone_name = zone.attributes["zone_name"]
 
 logger.info("updating next_watering for zone: ({}: {})".format(zone_name, zone))
 
-next_watering_entity = f"sensor.{zone_name}_next_watering"
+next_watering_entity = f"sensor.{zone_name}_next_watering".replace(" ", "_").lower()
 next_watering_attrs = {
     "friendly_name": f"{zone_name} next watering"
 }
 
-rain_delay_finishing_entity = f"sensor.{device_name}_rain_delay_finishing"
+rain_delay_finishing_entity = f"sensor.{device_name}_rain_delay_finishing".replace(" ", "_").lower()
 rain_delay_finishing_attrs = {
     "friendly_name": f"{device_name} rain delay finishing"
 }


### PR DESCRIPTION
Had errors with the entity name not valid (I had spaces in the device/zone name). Fix here is to do some basic formatting to get a format that works. Tested on my local installation, which only has the tap timers (i.e. single zone devices).