### PR TITLE
Add last run as age to sensor

### DIFF
--- a/custom_components/bhyve/sensor.py
+++ b/custom_components/bhyve/sensor.py
@@ -12,7 +12,7 @@ from .const import (
     EVENT_DEVICE_IDLE,
 )
 from .pybhyve.errors import BHyveError
-from .util import orbit_time_to_local_time, orbit_get_age
+from .util import orbit_time_to_local_time
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ ATTR_RUN_TIME = "run_time"
 ATTR_STATUS = "status"
 ATTR_CONSUMPTION_GALLONS = "consumption_gallons"
 ATTR_CONSUMPTION_LITRES = "consumption_litres"
-ATTR_LAST_RUN = "last_run"
+ATTR_START_TIME = "start_time"
 
 
 async def async_setup_platform(hass, config, async_add_entities, _discovery_info=None):
@@ -171,8 +171,7 @@ class BHyveZoneHistorySensor(BHyveDeviceEntity):
                     self._state = orbit_time_to_local_time(
                         latest_irrigation.get("start_time")
                     )
-                    # Log when it was last run
-                    _LOGGER.info("Bhyve: Last Run time: %s", orbit_get_age(latest_irrigation.get("start_time")))
+                    
                     self._attrs = {
                         ATTR_BUDGET: latest_irrigation.get(ATTR_BUDGET),
                         ATTR_PROGRAM: latest_irrigation.get(ATTR_PROGRAM),
@@ -181,7 +180,7 @@ class BHyveZoneHistorySensor(BHyveDeviceEntity):
                         ATTR_STATUS: latest_irrigation.get(ATTR_STATUS),
                         ATTR_CONSUMPTION_GALLONS: gallons,
                         ATTR_CONSUMPTION_LITRES: litres,
-                        ATTR_LAST_RUN: orbit_get_age(latest_irrigation.get("start_time")),
+                        ATTR_START_TIME: latest_irrigation.get(ATTR_START_TIME),
                     }
                     break
 

--- a/custom_components/bhyve/util.py
+++ b/custom_components/bhyve/util.py
@@ -6,11 +6,6 @@ def orbit_time_to_local_time(timestamp: str):
         return dt.as_local(dt.parse_datetime(timestamp))
     return None
 
-#Get last run date as age
-def orbit_get_age(timestamp: str):
-    if timestamp is not None:
-        return dt.get_age(dt.parse_datetime(timestamp))
-    return None
 
 def anonymize(device):
     device["address"] = "REDACTED"


### PR DESCRIPTION
Tiny modification to add the last run as age to the sensor. 
I find it useful to know how long ago the zone was watered.
I can then use a sensor like below:
```
  - platform: template
    sensors:
      bhyve_time_last_watered: 
        friendly_name: 'Bhyve - Time Last Watered'
        value_template: "{{state_attr('sensor.zone_history','last_run')}}"
        unique_id: 'bhyve_time_last_watered'
```
Note: this can quite easily be achieved directly in HA without the need for the mod; however, I feel it adds (little) extra functionality to the already awesome development. 
Thanks