### PR TITLE
Use EntityCategory enum instead of strings

### DIFF
--- a/custom_components/bhyve/sensor.py
+++ b/custom_components/bhyve/sensor.py
@@ -6,8 +6,8 @@ from homeassistant.const import (
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_TEMPERATURE,
     TEMP_FAHRENHEIT,
-    ENTITY_CATEGORY_DIAGNOSTIC,
 )
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.icon import icon_for_battery_level
 
 from homeassistant.components.sensor import (
@@ -121,7 +121,7 @@ class BHyveBatterySensor(BHyveDeviceEntity):
     @property
     def entity_category(self):
         """Battery is a diagnostic category"""
-        return ENTITY_CATEGORY_DIAGNOSTIC
+        return EntityCategory.DIAGNOSTIC
 
     def _should_handle_event(self, event_name, data):
         return event_name in [EVENT_CHANGE_MODE]
@@ -176,7 +176,7 @@ class BHyveZoneHistorySensor(BHyveDeviceEntity):
     @property
     def entity_category(self):
         """History is a diagnostic category"""
-        return ENTITY_CATEGORY_DIAGNOSTIC
+        return EntityCategory.DIAGNOSTIC
 
     def _should_handle_event(self, event_name, data):
         return event_name in [EVENT_DEVICE_IDLE]
@@ -254,7 +254,7 @@ class BHyveStateSensor(BHyveDeviceEntity):
     @property
     def entity_category(self):
         """Run state is a diagnostic category"""
-        return ENTITY_CATEGORY_DIAGNOSTIC
+        return EntityCategory.DIAGNOSTIC
 
     def _on_ws_data(self, data):
         """

--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -11,10 +11,11 @@ from homeassistant.components.switch import (
     SwitchEntity,
 )
 
-from homeassistant.const import ATTR_ENTITY_ID, ENTITY_CATEGORY_CONFIG
+from homeassistant.const import ATTR_ENTITY_ID 
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.event import async_call_later
 from homeassistant.util import dt
 
@@ -256,7 +257,7 @@ class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
     @property
     def entity_category(self):
         """Zone program is a configuration category"""
-        return ENTITY_CATEGORY_CONFIG
+        return EntityCategory.CONFIG
 
     async def _set_state(self, is_on):
         self._program.update({"enabled": is_on})
@@ -704,7 +705,7 @@ class BHyveRainDelaySwitch(BHyveDeviceEntity, SwitchEntity):
     @property
     def entity_category(self):
         """Rain delay is a configuration category"""
-        return ENTITY_CATEGORY_CONFIG
+        return EntityCategory.CONFIG
 
     async def async_turn_on(self):
         """Turn the switch on."""

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,6 @@
   "name": "Orbit BHyve",
   "domains": ["binary_sensor", "sensor", "switch"],
   "iot_class": "Cloud Push",
+  "homeassistant": "2021.12.0",
   "render_readme": true
 }


### PR DESCRIPTION
Specifying the entity category as a string doesn't work anymore starting in `2022.4`. You get these errors on startup right now in the current beta with this component installed:
```
2022-03-31 22:13:40 ERROR (MainThread) [homeassistant.components.switch] Error adding entities for domain switch with platform bhyve
Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 382, in async_add_entities
await asyncio.gather(*tasks)
File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 510, in _async_add_entity
entry = entity_registry.async_get_or_create(
File "/usr/src/homeassistant/homeassistant/helpers/entity_registry.py", line 345, in async_get_or_create
return self.async_update_entity(
File "/usr/src/homeassistant/homeassistant/helpers/entity_registry.py", line 529, in async_update_entity
raise ValueError("entity_category must be a valid EntityCategory instance")
ValueError: entity_category must be a valid EntityCategory instance
```

Using the EntityCategory enums instead fixes this.

The enums have been accepted since `2021.12` ([PR](https://github.com/home-assistant/core/pull/60720)) so it is safe to make immediately, don't have to wait for `2022.4`.

Also added a minimum supported version to `hacs.json` to reflect this. There wasn't one so I'm not sure if `2021.12.0` is actually your minimum supported version or if there is something else newer in use but I know it can't be lower then that with the enums.