### PR TITLE
Add "device_class: timestamp" to relevant sensors

### DIFF
--- a/custom_components/bhyve/sensor.py
+++ b/custom_components/bhyve/sensor.py
@@ -203,7 +203,7 @@ class BHyveZoneHistorySensor(BHyveDeviceEntity):
 
                     self._state = orbit_time_to_local_time(
                         latest_irrigation.get("start_time")
-                    )
+                    ).isoformat()
 
                     self._attrs = {
                         ATTR_BUDGET: latest_irrigation.get(ATTR_BUDGET),

--- a/custom_components/bhyve/sensor.py
+++ b/custom_components/bhyve/sensor.py
@@ -3,16 +3,12 @@ import logging
 
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
-    DEVICE_CLASS_BATTERY,
-    DEVICE_CLASS_TEMPERATURE,
     TEMP_FAHRENHEIT,
 )
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.icon import icon_for_battery_level
 
-from homeassistant.components.sensor import (
-    DEVICE_CLASS_TEMPERATURE,
-)
+from homeassistant.components.sensor import SensorDeviceClass
 
 from . import BHyveDeviceEntity
 from .const import (
@@ -73,7 +69,7 @@ class BHyveBatterySensor(BHyveDeviceEntity):
             device,
             name,
             "battery",
-            DEVICE_CLASS_BATTERY,
+            SensorDeviceClass.BATTERY,
         )
 
         self._unit = "%"
@@ -102,7 +98,7 @@ class BHyveBatterySensor(BHyveDeviceEntity):
     @property
     def icon(self):
         """Icon to use in the frontend, if any."""
-        if self._device_class == DEVICE_CLASS_BATTERY and self._state is not None:
+        if self._device_class == SensorDeviceClass.BATTERY and self._state is not None:
             return icon_for_battery_level(
                 battery_level=int(self._state), charging=False
             )
@@ -151,6 +147,7 @@ class BHyveZoneHistorySensor(BHyveDeviceEntity):
             device,
             name,
             "history",
+            SensorDeviceClass.TIMESTAMP,
         )
 
     def _setup(self, device):
@@ -276,7 +273,7 @@ class BHyveTemperatureSensor(BHyveDeviceEntity):
         name = "{0} temperature sensor".format(device.get("name"))
         _LOGGER.info("Creating temperature sensor: %s", name)
         super().__init__(
-            hass, bhyve, device, name, "thermometer", DEVICE_CLASS_TEMPERATURE
+            hass, bhyve, device, name, "thermometer", SensorDeviceClass.TEMPERATURE
         )
 
     def _setup(self, device):

--- a/python_scripts/bhyve_next_watering.py
+++ b/python_scripts/bhyve_next_watering.py
@@ -48,6 +48,7 @@ else:
         delay_finishes_at = dt_util.as_local(
             dt_util.utc_from_timestamp(started_at + delay_seconds)
         )
+        rain_delay_finishing_attrs.update({"device_class": "timestamp"})
         hass.states.set(
             rain_delay_finishing_entity, delay_finishes_at, rain_delay_finishing_attrs
         )
@@ -92,5 +93,5 @@ else:
             # next_watering_day = (
             #         filter(lambda day: (day > now_weekday), configured_days)
             #     )[0]# else configured_days[0]
-
+    next_watering_attrs.update({"device_class": "timestamp"})
     hass.states.set(next_watering_entity, next_watering, next_watering_attrs)

--- a/python_scripts/bhyve_next_watering.py
+++ b/python_scripts/bhyve_next_watering.py
@@ -47,7 +47,7 @@ else:
         delay_seconds = rain_delay.attributes.get("delay") * 3600
         delay_finishes_at = dt_util.as_local(
             dt_util.utc_from_timestamp(started_at + delay_seconds)
-        )
+        ).isoformat()
         rain_delay_finishing_attrs.update({"device_class": "timestamp"})
         hass.states.set(
             rain_delay_finishing_entity, delay_finishes_at, rain_delay_finishing_attrs
@@ -67,7 +67,7 @@ else:
                 if watering_time > now and (
                     delay_finishes_at is None or watering_time > delay_finishes_at
                 ):
-                    next_watering = watering_time
+                    next_watering = watering_time.isoformat()
                     break
         else:
             """ find the next manual watering time """


### PR DESCRIPTION
This change adds the [device class](https://www.home-assistant.io/integrations/sensor/) attribute `device_class: timestamp` to the "Zone Watering History" sensor indicating the most recent watering, and the "Next Scheduled Watering" sensor (created when running `bhyve_next_watering.py`). This makes it so that they appear in the dashboard as relative times (i.e., "Tomorrow") rather than as the full datetime value.

I've also eliminated the DEVICE_CLASS_* constants, which were [deprecated](https://www.home-assistant.io/blog/2021/12/11/release-202112/) in 2021.12 in favor of SensorDeviceClass.

This is working for me, but it should be tested by someone whose setup includes battery and temperature entities, which mine does not.