### PR TITLE
Fix not reconnecting after connection loss

### DIFF
--- a/custom_components/bhyve/pybhyve/websocket.py
+++ b/custom_components/bhyve/pybhyve/websocket.py
@@ -135,11 +135,13 @@ class OrbitWebsocket:
 
         except aiohttp.ClientConnectorError:
             _LOGGER.error("Client connection error; state: %s", self.state)
+            self.state = STATE_STOPPED
             self.retry()
 
         # pylint: disable=broad-except
         except Exception as err:
             _LOGGER.error("Unexpected error %s", err)
+            self.state = STATE_STOPPED
             self.retry()
 
         else:


### PR DESCRIPTION
In my observation i encountered that the component hangs on STATE_STARTING which prevents the retry to work (due to a check for STATE_STARTING on line 159)

With this fix i set the state to STATE_STOPPED before running a retry which resolves the problem on my side.

So even if the connection drops reconnecting is working properly.