### PR TITLE
Fix timedelta attribute error

### DIFF
--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -622,7 +622,7 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
             _LOGGER.warning(
                 "Switch %s manual preset runtime is 0, watering has defaulted to %s minutes. Set the manual run time on your device or please specify number of minutes using the bhyve.start_watering service",
                 self._device_name,
-                DEFAULT_MANUAL_RUNTIME.minutes,
+                int(DEFAULT_MANUAL_RUNTIME.seconds / 60),
             )
             run_time = 5
 


### PR DESCRIPTION
This PR addresses an error raised when attempting to toggle a zone switch. Specifically, when attempting to turn a zone switch on, the error message `Failed to call service switch/turn_on. 'datetime.timedelta' object has no attribute 'minutes'` is raised and the zone is not turned on.

Upon inspection, I found that the error is caused on line 625 of switch.py, in which the warning log call (to indicate manual preset runtime is 0) incorrectly attempts to use `DEFAULT_MANUAL_RUNTIME.minutes`. As `minutes` is not a valid attribute of a timedelta object (`DEFAULT_MANUAL_RUNTIME`), the error is raised. Resolved by changing this line to `int(DEFAULT_MANUAL_RUNTIME.seconds / 60)`.

For reference, this occurred on the following set up/versions:
Home Assistant: 2022.12.9
bhyve-home-assistant: 3.0.1 (Installed via HACS)
Irrigation Controller: 57950 (HW: WT25-0001, FW: 0032)

![zone_switch_error](https://user-images.githubusercontent.com/13740294/210624450-3667477c-48a2-454c-95d8-ee7d03869c77.jpg)
