### PR TITLE
Adding service to begin watering a program

### DIFF
--- a/custom_components/bhyve/services.yaml
+++ b/custom_components/bhyve/services.yaml
@@ -53,3 +53,10 @@ set_smart_watering_soil_moisture:
     percentage:
       description: Moisture level between 0 - 100 (percent)
       example: 50
+
+start_program:
+  description: Begin watering a program
+  fields:
+    entity_id:
+      description: Program
+      example: "switch.front_yard_program"

--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -283,7 +283,7 @@ class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
         
     async def start_program(self):
         """Begins running a program."""
-        station_payload = self._program_id
+        station_payload = self._program["program"]
         await self._send_program_message(station_payload)
 
     async def _send_program_message(self, station_payload):
@@ -298,7 +298,7 @@ class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
                 "timestamp": iso_time,
                 "program": station_payload,
             }
-            _LOGGER.info("Starting watering")
+            _LOGGER.info(payload)
             await self._bhyve.send_message(payload)
 
         except BHyveError as err:

--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -297,6 +297,7 @@ class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
                 "device_id": self._device_id,
                 "timestamp": iso_time,
                 "program": station_payload,
+                "stations": null,
             }
             _LOGGER.info("Starting watering")
             await self._bhyve.send_message(payload)

--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -283,7 +283,7 @@ class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
         
     async def start_program(self):
         """Begins running a program."""
-        station_payload = self.program
+        station_payload = self._program
         await self._send_program_message(station_payload)
 
     async def _send_program_message(self, station_payload):

--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -101,6 +101,7 @@ SERVICE_START_WATERING = "start_watering"
 SERVICE_STOP_WATERING = "stop_watering"
 SERVICE_SET_MANUAL_PRESET_RUNTIME = "set_manual_preset_runtime"
 SERVICE_SET_SMART_WATERING_SOIL_MOISTURE = "set_smart_watering_soil_moisture"
+SERVICE_START_PROGRAM = "start_program"
 
 
 SERVICE_TO_METHOD = {
@@ -124,6 +125,10 @@ SERVICE_TO_METHOD = {
     SERVICE_SET_SMART_WATERING_SOIL_MOISTURE: {
         "method": "set_smart_watering_soil_moisture",
         "schema": SET_SMART_WATERING_SOIL_MOISTURE_SCHEMA,
+    },
+    SERVICE_START_PROGRAM: {
+        "method": "start_program",
+        "schema": SERVICE_BASE_SCHEMA,
     },
 }
 

--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -297,7 +297,6 @@ class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
                 "device_id": self._device_id,
                 "timestamp": iso_time,
                 "program": station_payload,
-                "stations": null,
             }
             _LOGGER.info("Starting watering")
             await self._bhyve.send_message(payload)

--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -283,8 +283,7 @@ class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
         
     async def start_program(self):
         """Begins running a program."""
-        station_payload = [{"station": self._zone_id, "run_time": minutes}] #change
-        self._is_on = True #remove?
+        station_payload = self.program
         await self._send_station_message(station_payload) #change
 
 

--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -283,7 +283,7 @@ class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
         
     async def start_program(self):
         """Begins running a program."""
-        station_payload = self._program
+        station_payload = self._program_id
         await self._send_program_message(station_payload)
 
     async def _send_program_message(self, station_payload):

--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -637,7 +637,6 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
         station_payload = [{"station": self._zone_id, "run_time": minutes}]
         self._is_on = True
         await self._send_station_message(station_payload)
-        
     async def stop_watering(self):
         """Turns off the switch and stops watering."""
         station_payload = []

--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -298,7 +298,7 @@ class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
                 "timestamp": iso_time,
                 "program": station_payload,
             }
-            _LOGGER.info(payload)
+            _LOGGER.debug(payload)
             await self._bhyve.send_message(payload)
 
         except BHyveError as err:

--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -280,6 +280,13 @@ class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self._set_state(False)
+        
+    async def start_program(self):
+        """Begins running a program."""
+        station_payload = [{"station": self._zone_id, "run_time": minutes}] #change
+        self._is_on = True #remove?
+        await self._send_station_message(station_payload) #change
+
 
     async def async_added_to_hass(self):
         """Register callbacks."""
@@ -613,7 +620,7 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
         station_payload = [{"station": self._zone_id, "run_time": minutes}]
         self._is_on = True
         await self._send_station_message(station_payload)
-
+        
     async def stop_watering(self):
         """Turns off the switch and stops watering."""
         station_payload = []

--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -284,8 +284,26 @@ class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
     async def start_program(self):
         """Begins running a program."""
         station_payload = self.program
-        await self._send_station_message(station_payload) #change
+        await self._send_program_message(station_payload)
 
+    async def _send_program_message(self, station_payload):
+        try:
+            now = datetime.datetime.now()
+            iso_time = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+            payload = {
+                "event": EVENT_CHANGE_MODE,
+                "mode": "manual",
+                "device_id": self._device_id,
+                "timestamp": iso_time,
+                "program": station_payload,
+            }
+            _LOGGER.info("Starting watering")
+            await self._bhyve.send_message(payload)
+
+        except BHyveError as err:
+            _LOGGER.warning("Failed to send to BHyve websocket message %s", err)
+            raise (err)
 
     async def async_added_to_hass(self):
         """Register callbacks."""

--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -283,8 +283,8 @@ class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
         
     async def start_program(self):
         """Begins running a program."""
-        station_payload = self._program["program"]
-        await self._send_program_message(station_payload)
+        program_payload = self._program["program"]
+        await self._send_program_message(program_payload)
 
     async def _send_program_message(self, station_payload):
         try:


### PR DESCRIPTION
This PR will add a service “start_program” that requires a switch.program entity. Once called it will start watering that program.