### PR TITLE
Fix #236: Fix warning when updating battery from websocket event

### DIFF
--- a/custom_components/bhyve/sensor.py
+++ b/custom_components/bhyve/sensor.py
@@ -146,7 +146,7 @@ class BHyveBatterySensor(BHyveDeviceEntity):
         #
         event = data.get("event")
         if event in (EVENT_BATTERY_STATUS):
-            battery_level = self.parse_battery_level(event)
+            battery_level = self.parse_battery_level(data)
 
             self._state = battery_level
             self._attrs[ATTR_BATTERY_LEVEL] = battery_level


### PR DESCRIPTION
Fixes:

> Started seeing this today, for the first time, after updating:
> 
> `WARNING (MainThread) [custom_components.bhyve.sensor] Unexpected battery data, returning 0: battery_status`

