### PR TITLE
Fix sensor initialization

### DIFF
--- a/custom_components/bhyve/sensor.py
+++ b/custom_components/bhyve/sensor.py
@@ -57,6 +57,7 @@ async def async_setup_entry(
             all_zones = device.get("zones")
             for zone in all_zones:
                 # if the zone doesn't have a name, set it to the device's name if there is only one (eg a hose timer)
+                zone_name = zone.get("name", None)
                 if zone_name is None:
                     zone_name = (
                         device.get("name") if len(all_zones) == 1 else "Unnamed Zone"


### PR DESCRIPTION
This fixes the usage of an undefined variable. I was getting this error:

```
ERROR (MainThread) [homeassistant.components.sensor] Error while setting up bhyve platform for sensor
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 364, in _async_setup_platform
    await asyncio.shield(awaitable)
  File "/config/custom_components/bhyve/sensor.py", line 60, in async_setup_entry
    if zone_name is None:
       ^^^^^^^^^
UnboundLocalError: cannot access local variable 'zone_name' where it is not associated with a value
```

