### PR TITLE
fix: ImportError: cannot import name 'SensorStateClass' from 'homeassistant.const'

### DIFF
--- a/custom_components/bhyve/sensor.py
+++ b/custom_components/bhyve/sensor.py
@@ -5,7 +5,7 @@ import logging
 
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_BATTERY_LEVEL, SensorStateClass, UnitOfTemperature
+from homeassistant.const import ATTR_BATTERY_LEVEL, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback

--- a/custom_components/bhyve/sensor.py
+++ b/custom_components/bhyve/sensor.py
@@ -172,7 +172,7 @@ class BHyveBatterySensor(BHyveDeviceEntity):
         Otherwise, if the 'mv' attribute is present, the battery level is calculated as a percentage
         based on the millivolts, assuming that 2x1.5V AA batteries are used. Note that AA batteries can
         range from 1.2V to 1.7V depending on their chemistry, so the calculation may not be accurate
-        for all types of batteries. YMMV ¯\_(ツ)_/¯
+        for all types of batteries. YMMV
 
         Args:
         battery_data (dict): A dictionary containing the battery data.


### PR DESCRIPTION
Also fixes `WARNING (ImportExecutor_0) [py.warnings] /config/custom_components/bhyve/sensor.py:170: SyntaxWarning: invalid escape sequence '\_'`  which was triggered by  `¯\_(ツ)_/¯` in the comment block!