### PR TITLE
Turn off previous smart zone when progressing to next zone

### DIFF
--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -1,25 +1,33 @@
 """Support for Orbit BHyve switch (toggle zone)."""
+
 import datetime
-from datetime import timedelta
 import logging
+from datetime import timedelta
 from typing import Any
 
 import voluptuous as vol
-
 from homeassistant.components.switch import (
-    DOMAIN as SWITCH_DOMAIN,
     SwitchDeviceClass,
     SwitchEntity,
 )
+from homeassistant.components.switch.const import (
+    DOMAIN as SWITCH_DOMAIN,
+)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 from homeassistant.util import dt
+
+from custom_components.bhyve.pybhyve.client import BHyveClient
+from custom_components.bhyve.pybhyve.typings import (
+    BHyveDevice,
+    BHyveTimerProgram,
+    BHyveZone,
+)
 
 from . import BHyveDeviceEntity, BHyveWebsocketEntity
 from .const import (
@@ -142,7 +150,6 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the BHyve switch platform from a config entry."""
-
     bhyve = hass.data[DOMAIN][entry.entry_id][CONF_CLIENT]
 
     switches = []
@@ -157,7 +164,7 @@ async def async_setup_entry(
         if device.get("type") == DEVICE_SPRINKLER:
             if not device.get("status"):
                 _LOGGER.warning(
-                    "Unable to configure device %s: the 'status' attribute is missing. Has it been paired with the wifi hub?",
+                    "Unable to configure device %s: the 'status' attribute is missing. Has it been paired with the wifi hub?",  # noqa: E501
                     device.get("name"),
                 )
                 continue
@@ -174,7 +181,7 @@ async def async_setup_entry(
             all_zones = device.get("zones")
             for zone in all_zones:
                 zone_name = zone.get("name")
-                # if the zone doesn't have a name, set it to the device's name if there is only one (eg a hose timer)
+                # if the zone doesn't have a name, set it to the device's name if there is only one (eg a hose timer)  # noqa: E501
                 if zone_name is None:
                     zone_name = (
                         device.get("name") if len(all_zones) == 1 else "Unnamed Zone"
@@ -202,9 +209,9 @@ async def async_setup_entry(
                 )
             )
 
-    async_add_entities(switches, True)
+    async_add_entities(switches, True)  # noqa: FBT003
 
-    async def async_service_handler(service):
+    async def async_service_handler(service: Any) -> None:
         """Map services to method of BHyve devices."""
         _LOGGER.info("%s service called", service.service)
         method = SERVICE_TO_METHOD.get(service.service)
@@ -217,7 +224,7 @@ async def async_setup_entry(
         }
         entity_ids = service.data.get(ATTR_ENTITY_ID)
         component = hass.data.get(SWITCH_DOMAIN)
-        if entity_ids:
+        if entity_ids and component is not None:
             target_switches = [component.get_entity(entity) for entity in entity_ids]
         else:
             return
@@ -241,7 +248,14 @@ async def async_setup_entry(
 class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
     """Define a BHyve program switch."""
 
-    def __init__(self, hass, bhyve, device, program, icon):
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        bhyve: BHyveClient,
+        device: BHyveDevice,
+        program: BHyveTimerProgram,
+        icon: str,
+    ) -> None:
         """Initialize the switch."""
         device_name = device.get("name", "Unknown switch")
         program_name = program.get("name", "unknown")
@@ -256,10 +270,9 @@ class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
         self._available = True
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
-
-        attrs = {
+        return {
             "device_id": self._device_id,
             "is_smart_program": self._program.get("is_smart_program", False),
             "frequency": self._program.get("frequency"),
@@ -269,43 +282,41 @@ class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
             "run_times": self._program.get("run_times"),
         }
 
-        return attrs
-
     @property
-    def is_on(self):
+    def is_on(self) -> bool:
         """Return the status of the sensor."""
         return self._program.get("enabled") is True
 
     @property
-    def unique_id(self):
+    def unique_id(self) -> str:
         """Return the unique id for the switch program."""
         return f"bhyve:program:{self._program_id}"
 
     @property
-    def entity_category(self):
+    def entity_category(self) -> EntityCategory:
         """Zone program is a configuration category."""
         return EntityCategory.CONFIG
 
-    async def _set_state(self, is_on):
+    async def _set_state(self, is_on: bool) -> None:  # noqa: FBT001
         self._program.update({"enabled": is_on})
         await self._bhyve.update_program(self._program_id, self._program)
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self) -> None:
         """Turn the switch on."""
-        await self._set_state(True)
+        await self._set_state(True)  # noqa: FBT003
 
-    async def async_turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self) -> None:
         """Turn the switch off."""
-        await self._set_state(False)
+        await self._set_state(False)  # noqa: FBT003
 
-    async def start_program(self):
+    async def start_program(self) -> None:
         """Begins running a program."""
         program_payload = self._program["program"]
         await self._send_program_message(program_payload)
 
-    async def _send_program_message(self, station_payload):
+    async def _send_program_message(self, station_payload: Any) -> None:
         try:
-            now = datetime.datetime.now()
+            now = datetime.datetime.now()  # noqa: DTZ005 - be timezone aware?
             iso_time = now.strftime("%Y-%m-%dT%H:%M:%SZ")
 
             payload = {
@@ -322,11 +333,11 @@ class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
             _LOGGER.warning("Failed to send to BHyve websocket message %s", err)
             raise (err)
 
-    async def async_added_to_hass(self):
+    async def async_added_to_hass(self) -> None:
         """Register callbacks."""
 
         @callback
-        def update(device_id, data):
+        def update(_device_id: str, data: dict) -> None:
             """Update the state."""
             _LOGGER.info(
                 "Program update: %s - %s - %s", self.name, self._program_id, str(data)
@@ -334,20 +345,20 @@ class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
             event = data.get("event")
             if event == EVENT_PROGRAM_CHANGED:
                 self._ws_unprocessed_events.append(data)
-                self.async_schedule_update_ha_state(True)
+                self.async_schedule_update_ha_state(True)  # noqa: FBT003
 
         self._async_unsub_dispatcher_connect = async_dispatcher_connect(
             self.hass, SIGNAL_UPDATE_PROGRAM.format(self._program_id), update
         )
 
-    async def async_will_remove_from_hass(self):
+    async def async_will_remove_from_hass(self) -> None:
         """Disconnect dispatcher listener when removed."""
         if self._async_unsub_dispatcher_connect:
             self._async_unsub_dispatcher_connect()
 
-    def _on_ws_data(self, data):
+    def _on_ws_data(self, data: dict) -> None:
         #
-        # {'event': 'program_changed' }
+        # {'event': 'program_changed' }  # noqa: ERA001
         #
         _LOGGER.info("Received program data update %s", data)
 
@@ -361,22 +372,31 @@ class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
             if program is not None:
                 self._program = program
 
-    def _should_handle_event(self, event_name, data):
+    def _should_handle_event(self, event_name: str, _data: dict) -> bool:
         return event_name in [EVENT_PROGRAM_CHANGED]
 
 
 class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
     """Define a BHyve zone switch."""
 
-    def __init__(self, hass, bhyve, device, zone, zone_name, device_programs, icon):
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        bhyve: BHyveClient,
+        device: BHyveDevice,
+        zone: BHyveZone,
+        zone_name: str,
+        device_programs: list[BHyveTimerProgram],
+        icon: str,
+    ) -> None:
         """Initialize the switch."""
-        self._is_on = False
-        self._zone = zone
-        self._zone_id = zone.get("station")
-        self._entity_picture = zone.get("image_url")
-        self._zone_name = zone_name
-        self._smart_watering_enabled = zone.get("smart_watering_enabled")
-        self._manual_preset_runtime = device.get(
+        self._is_on: bool = False
+        self._zone: BHyveZone = zone
+        self._zone_id: str = zone.get("station", "")
+        self._entity_picture: str | None = zone.get("image_url")
+        self._zone_name: str = zone_name
+        self._smart_watering_enabled: bool = zone.get("smart_watering_enabled", False)
+        self._manual_preset_runtime: int = device.get(
             "manual_preset_runtime_sec", DEFAULT_MANUAL_RUNTIME.seconds
         )
 
@@ -387,7 +407,7 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
 
         super().__init__(hass, bhyve, device, name, icon, SwitchDeviceClass.SWITCH)
 
-    def _setup(self, device):
+    def _setup(self, device: BHyveDevice) -> None:
         self._is_on = False
         self._attrs = {
             "device_name": self._device_name,
@@ -415,9 +435,7 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
             self._is_on = is_watering
             self._attrs[ATTR_MANUAL_RUNTIME] = self._manual_preset_runtime
 
-            next_start_time = orbit_time_to_local_time(
-                status.get("next_start_time")
-            )
+            next_start_time = orbit_time_to_local_time(status.get("next_start_time"))
             if next_start_time is not None:
                 next_start_programs = status.get("next_start_programs")
                 self._attrs.update(
@@ -440,10 +458,7 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
                 current_station = watering_status.get("current_station")
                 current_program = watering_status.get("program", None)
                 stations = watering_status.get("stations")
-                if stations:
-                    current_runtime = stations[0].get("run_time")
-                else:
-                    current_runtime = None
+                current_runtime = stations[0].get("run_time") if stations else None
                 self._set_watering_started(
                     started_watering_at,
                     current_station,
@@ -457,7 +472,13 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
                 self._set_watering_program(program)
             self._initial_programs = None
 
-    def _set_watering_started(self, timestamp, station, program, runtime):
+    def _set_watering_started(
+        self,
+        timestamp: str | None,
+        station: str | None,
+        program: str | None,
+        runtime: int | None,
+    ) -> None:
         started_watering_at_timestamp = (
             orbit_time_to_local_time(timestamp) if timestamp is not None else None
         )
@@ -471,7 +492,7 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
             }
         )
 
-    def _set_watering_program(self, program):
+    def _set_watering_program(self, program: BHyveTimerProgram | None) -> None:
         if program is None:
             return
 
@@ -510,14 +531,14 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
 
             return
 
-        #
+        """
         #    "name": "Backyard",
         #    "frequency": { "type": "days", "days": [1, 4] },
         #    "start_times": ["07:30"],
         #    "budget": 100,
         #    "program": "a",
         #    "run_times": [{ "run_time": 20, "station": 1 }],
-        #
+        """
 
         if is_smart_program is True:
             upcoming_run_times = []
@@ -531,13 +552,14 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
                         plan_date = orbit_time_to_local_time(plan.get("date"))
                         for time in plan.get("start_times", []):
                             upcoming_time = dt.parse_time(time)
-                            upcoming_run_times.append(
-                                plan_date
-                                + timedelta(
-                                    hours=upcoming_time.hour,
-                                    minutes=upcoming_time.minute,
+                            if upcoming_time is not None and plan_date is not None:
+                                upcoming_run_times.append(
+                                    plan_date
+                                    + timedelta(
+                                        hours=upcoming_time.hour,
+                                        minutes=upcoming_time.minute,
+                                    )
                                 )
-                            )
             self._attrs[program_attr].update(
                 {ATTR_SMART_WATERING_PLAN: upcoming_run_times}
             )
@@ -550,7 +572,7 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
                 }
             )
 
-    def _should_handle_event(self, event_name, data):
+    def _should_handle_event(self, event_name: str, _data: dict) -> bool:
         return event_name in [
             EVENT_CHANGE_MODE,
             EVENT_DEVICE_IDLE,
@@ -560,13 +582,15 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
             EVENT_WATERING_IN_PROGRESS,
         ]
 
-    def _on_ws_data(self, data):
-        #
+    def _on_ws_data(self, data: dict) -> None:
+        """
+        Handle websocket data.
+
         # {'event': 'watering_in_progress_notification', 'program': 'e', 'current_station': 1, 'run_time': 14, 'started_watering_station_at': '2020-01-09T20:29:59.000Z', 'rain_sensor_hold': False, 'device_id': 'id', 'timestamp': '2020-01-09T20:29:59.000Z'}
         # {'event': 'device_idle', 'device_id': 'id', 'timestamp': '2020-01-10T12:32:06.000Z'}
         # {'event': 'set_manual_preset_runtime', 'device_id': 'id', 'seconds': 480, 'timestamp': '2020-01-18T17:00:35.000Z'}
         # {'event': 'program_changed' }
-        #
+        """  # noqa: E501
         event = data.get("event")
         if event in (EVENT_DEVICE_IDLE, EVENT_WATERING_COMPLETE) or (
             event == EVENT_CHANGE_MODE and data.get("mode") in ("off", "auto")
@@ -602,15 +626,11 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
                         )
                         self._is_on = False
                         self._set_watering_started(None, None, None, None)
-        elif event == "change_mode":
-            mode = data.get("mode")
-            # Ignore benign 'auto' while watering
-            if mode == "off":
-                self._is_on = False
-                self._set_watering_started(None, None, None, None)
         elif event == EVENT_SET_MANUAL_PRESET_TIME:
-            self._manual_preset_runtime = data.get("seconds")
-            self._attrs[ATTR_MANUAL_RUNTIME] = self._manual_preset_runtime
+            manual_preset_runtime = data.get("seconds")
+            if manual_preset_runtime is not None:
+                self._manual_preset_runtime = manual_preset_runtime
+                self._attrs[ATTR_MANUAL_RUNTIME] = manual_preset_runtime
         elif event == EVENT_PROGRAM_CHANGED:
             watering_program = data.get("program")
             lifecycle_phase = data.get("lifecycle_phase")
@@ -619,9 +639,9 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
             else:
                 self._attrs[ATTR_SMART_WATERING_PLAN] = None
 
-    async def _send_station_message(self, station_payload):
+    async def _send_station_message(self, station_payload: Any) -> None:
         try:
-            now = datetime.datetime.now()
+            now = datetime.datetime.now()  # noqa: DTZ005 - be timezone aware?
             iso_time = now.strftime("%Y-%m-%dT%H:%M:%SZ")
 
             payload = {
@@ -639,21 +659,21 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
             raise (err)
 
     @property
-    def entity_picture(self):
+    def entity_picture(self) -> str | None:
         """Return picture of the entity."""
         return self._entity_picture
 
     @property
-    def unique_id(self):
+    def unique_id(self) -> str:
         """Return a unique, unchanging string that represents this switch."""
         return f"{self._mac_address}:{self._device_id}:{self._zone_id}:switch"
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool:
         """Return the status of the sensor."""
         return self._is_on
 
-    async def set_smart_watering_soil_moisture(self, percentage):
+    async def set_smart_watering_soil_moisture(self, percentage: float) -> None:
         """Set the soil moisture percentage for the zone."""
         if self._smart_watering_enabled:
             landscape = None
@@ -711,24 +731,24 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
                 self._zone_name,
             )
 
-    async def start_watering(self, minutes):
-        """Turns on the switch and starts watering."""
+    async def start_watering(self, minutes: float) -> None:
+        """Turn on the switch and starts watering."""
         station_payload = [{"station": self._zone_id, "run_time": minutes}]
         self._is_on = True
         await self._send_station_message(station_payload)
 
-    async def stop_watering(self):
-        """Turns off the switch and stops watering."""
+    async def stop_watering(self) -> None:
+        """Turn off the switch and stops watering."""
         station_payload = []
         self._is_on = False
         await self._send_station_message(station_payload)
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self) -> None:
         """Turn the switch on."""
         run_time = self._manual_preset_runtime / 60
         if run_time == 0:
             _LOGGER.warning(
-                "Switch %s manual preset runtime is 0, watering has defaulted to %s minutes. Set the manual run time on your device or please specify number of minutes using the bhyve.start_watering service",
+                "Switch %s manual preset runtime is 0, watering has defaulted to %s minutes. Set the manual run time on your device or please specify number of minutes using the bhyve.start_watering service",  # noqa: E501
                 self._device_name,
                 int(DEFAULT_MANUAL_RUNTIME.seconds / 60),
             )
@@ -736,7 +756,7 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
 
         await self.start_watering(run_time)
 
-    async def async_turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self) -> None:
         """Turn the switch off."""
         await self.stop_watering()
 
@@ -744,7 +764,9 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
 class BHyveRainDelaySwitch(BHyveDeviceEntity, SwitchEntity):
     """Define a BHyve rain delay switch."""
 
-    def __init__(self, hass, bhyve, device, icon):
+    def __init__(
+        self, hass: HomeAssistant, bhyve: BHyveClient, device: BHyveDevice, icon: str
+    ) -> None:
         """Initialize the switch."""
         name = "{} rain delay".format(device.get("name"))
         _LOGGER.info("Creating switch: %s", name)
@@ -754,58 +776,67 @@ class BHyveRainDelaySwitch(BHyveDeviceEntity, SwitchEntity):
 
         super().__init__(hass, bhyve, device, name, icon, SwitchDeviceClass.SWITCH)
 
-    def _setup(self, device):
+    def _setup(self, device: BHyveDevice) -> None:
         self._is_on = False
         self._attrs = {
             "device_id": self._device_id,
         }
         self._available = device.get("is_connected", False)
 
-        device_status = device.get("status")
+        device_status = device.get("status", {})
         rain_delay = device_status.get("rain_delay")
 
         self._update_device_cb = None
         self._extract_rain_delay(rain_delay, device_status)
 
-    def _on_ws_data(self, data):
-        #
+    def _on_ws_data(self, data: dict) -> None:
+        """
+        Handle websocket data.
+
         # {'event': 'rain_delay', 'device_id': 'id', 'delay': 0, 'timestamp': '2020-01-14T12:10:10.000Z'}
-        #
+        """  # noqa: E501
         event = data.get("event")
         if event is None:
             _LOGGER.warning("No event on ws data %s", data)
             return
 
         if event == EVENT_RAIN_DELAY:
-            self._extract_rain_delay(
-                data.get("delay"), {"rain_delay_started_at": data.get("timestamp")}
-            )
-            # The REST API returns more data about a rain delay (eg cause/weather_type)
-            self._update_device_soon()
+            delay = data.get("delay")
+            if delay is not None:
+                self._extract_rain_delay(
+                    delay, {"rain_delay_started_at": data.get("timestamp")}
+                )
+                # The REST API returns more data about a rain delay
+                # (eg cause/weather_type)
+                self._update_device_soon()
 
-    def _should_handle_event(self, event_name, data):
+    def _should_handle_event(self, event_name: str, _data: dict) -> bool:
         return event_name in [EVENT_RAIN_DELAY]
 
-    def _update_device_soon(self):
+    def _update_device_soon(self) -> None:
         if self._update_device_cb is not None:
             self._update_device_cb()  # unsubscribe
         self._update_device_cb = async_call_later(self._hass, 1, self._update_device)
 
-    async def _update_device(self, time):
+    async def _update_device(self, _time: Any) -> None:
         await self._refetch_device(force_update=True)
         self.async_schedule_update_ha_state()
 
-    def _extract_rain_delay(self, rain_delay, device_status=None):
+    def _extract_rain_delay(
+        self, rain_delay: int, device_status: dict | None = None
+    ) -> None:
         if rain_delay is not None and rain_delay > 0:
             self._is_on = True
-            self._attrs = {ATTR_DELAY: rain_delay}
+            self._attrs: dict[str, Any] = {ATTR_DELAY: rain_delay}
             if device_status is not None:
                 self._attrs.update(
                     {
-                        ATTR_CAUSE: device_status.get("rain_delay_cause"),
-                        ATTR_WEATHER_TYPE: device_status.get("rain_delay_weather_type"),
+                        ATTR_CAUSE: device_status.get("rain_delay_cause", "Unknown"),
+                        ATTR_WEATHER_TYPE: device_status.get(
+                            "rain_delay_weather_type", "Unknown"
+                        ),
                         ATTR_STARTED_AT: orbit_time_to_local_time(
-                            device_status.get("rain_delay_started_at")
+                            device_status.get("rain_delay_started_at", "")
                         ),
                     }
                 )
@@ -814,26 +845,26 @@ class BHyveRainDelaySwitch(BHyveDeviceEntity, SwitchEntity):
             self._attrs = {}
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool:
         """Return the status of the sensor."""
         return self._is_on
 
     @property
-    def unique_id(self):
+    def unique_id(self) -> str:
         """Return a unique, unchanging string that represents this sensor."""
         return f"{self._mac_address}:{self._device_id}:rain_delay"
 
     @property
-    def entity_category(self):
+    def entity_category(self) -> str:
         """Rain delay is a configuration category."""
         return EntityCategory.CONFIG
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self) -> None:
         """Turn the switch on."""
         self._is_on = True
         await self.enable_rain_delay()
 
-    async def async_turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self) -> None:
         """Turn the switch off."""
         self._is_on = False
         await self.disable_rain_delay()

--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -1,33 +1,25 @@
 """Support for Orbit BHyve switch (toggle zone)."""
-
 import datetime
-import logging
 from datetime import timedelta
+import logging
 from typing import Any
 
 import voluptuous as vol
+
 from homeassistant.components.switch import (
+    DOMAIN as SWITCH_DOMAIN,
     SwitchDeviceClass,
     SwitchEntity,
 )
-from homeassistant.components.switch.const import (
-    DOMAIN as SWITCH_DOMAIN,
-)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ENTITY_ID, EntityCategory
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 from homeassistant.util import dt
-
-from custom_components.bhyve.pybhyve.client import BHyveClient
-from custom_components.bhyve.pybhyve.typings import (
-    BHyveDevice,
-    BHyveTimerProgram,
-    BHyveZone,
-)
 
 from . import BHyveDeviceEntity, BHyveWebsocketEntity
 from .const import (
@@ -150,6 +142,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the BHyve switch platform from a config entry."""
+
     bhyve = hass.data[DOMAIN][entry.entry_id][CONF_CLIENT]
 
     switches = []
@@ -164,7 +157,7 @@ async def async_setup_entry(
         if device.get("type") == DEVICE_SPRINKLER:
             if not device.get("status"):
                 _LOGGER.warning(
-                    "Unable to configure device %s: the 'status' attribute is missing. Has it been paired with the wifi hub?",  # noqa: E501
+                    "Unable to configure device %s: the 'status' attribute is missing. Has it been paired with the wifi hub?",
                     device.get("name"),
                 )
                 continue
@@ -181,7 +174,7 @@ async def async_setup_entry(
             all_zones = device.get("zones")
             for zone in all_zones:
                 zone_name = zone.get("name")
-                # if the zone doesn't have a name, set it to the device's name if there is only one (eg a hose timer)  # noqa: E501
+                # if the zone doesn't have a name, set it to the device's name if there is only one (eg a hose timer)
                 if zone_name is None:
                     zone_name = (
                         device.get("name") if len(all_zones) == 1 else "Unnamed Zone"
@@ -209,9 +202,9 @@ async def async_setup_entry(
                 )
             )
 
-    async_add_entities(switches, True)  # noqa: FBT003
+    async_add_entities(switches, True)
 
-    async def async_service_handler(service: Any) -> None:
+    async def async_service_handler(service):
         """Map services to method of BHyve devices."""
         _LOGGER.info("%s service called", service.service)
         method = SERVICE_TO_METHOD.get(service.service)
@@ -224,7 +217,7 @@ async def async_setup_entry(
         }
         entity_ids = service.data.get(ATTR_ENTITY_ID)
         component = hass.data.get(SWITCH_DOMAIN)
-        if entity_ids and component is not None:
+        if entity_ids:
             target_switches = [component.get_entity(entity) for entity in entity_ids]
         else:
             return
@@ -248,14 +241,7 @@ async def async_setup_entry(
 class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
     """Define a BHyve program switch."""
 
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        bhyve: BHyveClient,
-        device: BHyveDevice,
-        program: BHyveTimerProgram,
-        icon: str,
-    ) -> None:
+    def __init__(self, hass, bhyve, device, program, icon):
         """Initialize the switch."""
         device_name = device.get("name", "Unknown switch")
         program_name = program.get("name", "unknown")
@@ -270,9 +256,10 @@ class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
         self._available = True
 
     @property
-    def extra_state_attributes(self) -> dict[str, Any]:
+    def extra_state_attributes(self):
         """Return the device state attributes."""
-        return {
+
+        attrs = {
             "device_id": self._device_id,
             "is_smart_program": self._program.get("is_smart_program", False),
             "frequency": self._program.get("frequency"),
@@ -282,41 +269,43 @@ class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
             "run_times": self._program.get("run_times"),
         }
 
+        return attrs
+
     @property
-    def is_on(self) -> bool:
+    def is_on(self):
         """Return the status of the sensor."""
         return self._program.get("enabled") is True
 
     @property
-    def unique_id(self) -> str:
+    def unique_id(self):
         """Return the unique id for the switch program."""
         return f"bhyve:program:{self._program_id}"
 
     @property
-    def entity_category(self) -> EntityCategory:
+    def entity_category(self):
         """Zone program is a configuration category."""
         return EntityCategory.CONFIG
 
-    async def _set_state(self, is_on: bool) -> None:  # noqa: FBT001
+    async def _set_state(self, is_on):
         self._program.update({"enabled": is_on})
         await self._bhyve.update_program(self._program_id, self._program)
 
-    async def async_turn_on(self) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        await self._set_state(True)  # noqa: FBT003
+        await self._set_state(True)
 
-    async def async_turn_off(self) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        await self._set_state(False)  # noqa: FBT003
+        await self._set_state(False)
 
-    async def start_program(self) -> None:
+    async def start_program(self):
         """Begins running a program."""
         program_payload = self._program["program"]
         await self._send_program_message(program_payload)
 
-    async def _send_program_message(self, station_payload: Any) -> None:
+    async def _send_program_message(self, station_payload):
         try:
-            now = datetime.datetime.now()  # noqa: DTZ005 - be timezone aware?
+            now = datetime.datetime.now()
             iso_time = now.strftime("%Y-%m-%dT%H:%M:%SZ")
 
             payload = {
@@ -333,11 +322,11 @@ class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
             _LOGGER.warning("Failed to send to BHyve websocket message %s", err)
             raise (err)
 
-    async def async_added_to_hass(self) -> None:
+    async def async_added_to_hass(self):
         """Register callbacks."""
 
         @callback
-        def update(_device_id: str, data: dict) -> None:
+        def update(device_id, data):
             """Update the state."""
             _LOGGER.info(
                 "Program update: %s - %s - %s", self.name, self._program_id, str(data)
@@ -345,20 +334,20 @@ class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
             event = data.get("event")
             if event == EVENT_PROGRAM_CHANGED:
                 self._ws_unprocessed_events.append(data)
-                self.async_schedule_update_ha_state(True)  # noqa: FBT003
+                self.async_schedule_update_ha_state(True)
 
         self._async_unsub_dispatcher_connect = async_dispatcher_connect(
             self.hass, SIGNAL_UPDATE_PROGRAM.format(self._program_id), update
         )
 
-    async def async_will_remove_from_hass(self) -> None:
+    async def async_will_remove_from_hass(self):
         """Disconnect dispatcher listener when removed."""
         if self._async_unsub_dispatcher_connect:
             self._async_unsub_dispatcher_connect()
 
-    def _on_ws_data(self, data: dict) -> None:
+    def _on_ws_data(self, data):
         #
-        # {'event': 'program_changed' }  # noqa: ERA001
+        # {'event': 'program_changed' }
         #
         _LOGGER.info("Received program data update %s", data)
 
@@ -372,31 +361,22 @@ class BHyveProgramSwitch(BHyveWebsocketEntity, SwitchEntity):
             if program is not None:
                 self._program = program
 
-    def _should_handle_event(self, event_name: str, _data: dict) -> bool:
+    def _should_handle_event(self, event_name, data):
         return event_name in [EVENT_PROGRAM_CHANGED]
 
 
 class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
     """Define a BHyve zone switch."""
 
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        bhyve: BHyveClient,
-        device: BHyveDevice,
-        zone: BHyveZone,
-        zone_name: str,
-        device_programs: list[BHyveTimerProgram],
-        icon: str,
-    ) -> None:
+    def __init__(self, hass, bhyve, device, zone, zone_name, device_programs, icon):
         """Initialize the switch."""
-        self._is_on: bool = False
-        self._zone: BHyveZone = zone
-        self._zone_id: str = zone.get("station", "")
-        self._entity_picture: str | None = zone.get("image_url")
-        self._zone_name: str = zone_name
-        self._smart_watering_enabled: bool = zone.get("smart_watering_enabled", False)
-        self._manual_preset_runtime: int = device.get(
+        self._is_on = False
+        self._zone = zone
+        self._zone_id = zone.get("station")
+        self._entity_picture = zone.get("image_url")
+        self._zone_name = zone_name
+        self._smart_watering_enabled = zone.get("smart_watering_enabled")
+        self._manual_preset_runtime = device.get(
             "manual_preset_runtime_sec", DEFAULT_MANUAL_RUNTIME.seconds
         )
 
@@ -407,7 +387,7 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
 
         super().__init__(hass, bhyve, device, name, icon, SwitchDeviceClass.SWITCH)
 
-    def _setup(self, device: BHyveDevice) -> None:
+    def _setup(self, device):
         self._is_on = False
         self._attrs = {
             "device_name": self._device_name,
@@ -435,7 +415,9 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
             self._is_on = is_watering
             self._attrs[ATTR_MANUAL_RUNTIME] = self._manual_preset_runtime
 
-            next_start_time = orbit_time_to_local_time(status.get("next_start_time"))
+            next_start_time = orbit_time_to_local_time(
+                status.get("next_start_time")
+            )
             if next_start_time is not None:
                 next_start_programs = status.get("next_start_programs")
                 self._attrs.update(
@@ -458,7 +440,10 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
                 current_station = watering_status.get("current_station")
                 current_program = watering_status.get("program", None)
                 stations = watering_status.get("stations")
-                current_runtime = stations[0].get("run_time") if stations else None
+                if stations:
+                    current_runtime = stations[0].get("run_time")
+                else:
+                    current_runtime = None
                 self._set_watering_started(
                     started_watering_at,
                     current_station,
@@ -472,13 +457,7 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
                 self._set_watering_program(program)
             self._initial_programs = None
 
-    def _set_watering_started(
-        self,
-        timestamp: str | None,
-        station: str | None,
-        program: str | None,
-        runtime: int | None,
-    ) -> None:
+    def _set_watering_started(self, timestamp, station, program, runtime):
         started_watering_at_timestamp = (
             orbit_time_to_local_time(timestamp) if timestamp is not None else None
         )
@@ -492,7 +471,7 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
             }
         )
 
-    def _set_watering_program(self, program: BHyveTimerProgram | None) -> None:
+    def _set_watering_program(self, program):
         if program is None:
             return
 
@@ -531,14 +510,14 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
 
             return
 
-        """
+        #
         #    "name": "Backyard",
         #    "frequency": { "type": "days", "days": [1, 4] },
         #    "start_times": ["07:30"],
         #    "budget": 100,
         #    "program": "a",
         #    "run_times": [{ "run_time": 20, "station": 1 }],
-        """
+        #
 
         if is_smart_program is True:
             upcoming_run_times = []
@@ -552,14 +531,13 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
                         plan_date = orbit_time_to_local_time(plan.get("date"))
                         for time in plan.get("start_times", []):
                             upcoming_time = dt.parse_time(time)
-                            if upcoming_time is not None and plan_date is not None:
-                                upcoming_run_times.append(
-                                    plan_date
-                                    + timedelta(
-                                        hours=upcoming_time.hour,
-                                        minutes=upcoming_time.minute,
-                                    )
+                            upcoming_run_times.append(
+                                plan_date
+                                + timedelta(
+                                    hours=upcoming_time.hour,
+                                    minutes=upcoming_time.minute,
                                 )
+                            )
             self._attrs[program_attr].update(
                 {ATTR_SMART_WATERING_PLAN: upcoming_run_times}
             )
@@ -572,7 +550,7 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
                 }
             )
 
-    def _should_handle_event(self, event_name: str, _data: dict) -> bool:
+    def _should_handle_event(self, event_name, data):
         return event_name in [
             EVENT_CHANGE_MODE,
             EVENT_DEVICE_IDLE,
@@ -582,15 +560,13 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
             EVENT_WATERING_IN_PROGRESS,
         ]
 
-    def _on_ws_data(self, data: dict) -> None:
-        """
-        Handle websocket data.
-
+    def _on_ws_data(self, data):
+        #
         # {'event': 'watering_in_progress_notification', 'program': 'e', 'current_station': 1, 'run_time': 14, 'started_watering_station_at': '2020-01-09T20:29:59.000Z', 'rain_sensor_hold': False, 'device_id': 'id', 'timestamp': '2020-01-09T20:29:59.000Z'}
         # {'event': 'device_idle', 'device_id': 'id', 'timestamp': '2020-01-10T12:32:06.000Z'}
         # {'event': 'set_manual_preset_runtime', 'device_id': 'id', 'seconds': 480, 'timestamp': '2020-01-18T17:00:35.000Z'}
         # {'event': 'program_changed' }
-        """  # noqa: E501
+        #
         event = data.get("event")
         if event in (EVENT_DEVICE_IDLE, EVENT_WATERING_COMPLETE) or (
             event == EVENT_CHANGE_MODE and data.get("mode") in ("off", "auto")
@@ -598,11 +574,13 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
             self._is_on = False
             self._set_watering_started(None, None, None, None)
         elif event == EVENT_WATERING_IN_PROGRESS:
-            zone = data.get("current_station")
-            if zone == self._zone_id:
+            current_station = data.get("current_station")
+
+            # Normalize ids
+            if current_station is not None and str(current_station) == str(self._zone_id):
+                # This is *my* zone running
                 self._is_on = True
                 started_watering_at = data.get("started_watering_station_at")
-                current_station = data.get("current_station")
                 current_program = data.get("program")
                 current_runtime = data.get("run_time")
 
@@ -612,11 +590,27 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
                     current_program,
                     current_runtime,
                 )
+            else:
+                # Only turn off on watering_in_progress if another station is *actually active*
+                if current_station is not None and self._is_on:
+                    if str(current_station) != str(self._zone_id):
+                        _LOGGER.debug(
+                            "%s: Another station (%s) is watering, marking this zone (%s) off",
+                            self.name,
+                            current_station,
+                            self._zone_id,
+                        )
+                        self._is_on = False
+                        self._set_watering_started(None, None, None, None)
+        elif event == "change_mode":
+            mode = data.get("mode")
+            # Ignore benign 'auto' while watering
+            if mode == "off":
+                self._is_on = False
+                self._set_watering_started(None, None, None, None)
         elif event == EVENT_SET_MANUAL_PRESET_TIME:
-            manual_preset_runtime = data.get("seconds")
-            if manual_preset_runtime is not None:
-                self._manual_preset_runtime = manual_preset_runtime
-                self._attrs[ATTR_MANUAL_RUNTIME] = manual_preset_runtime
+            self._manual_preset_runtime = data.get("seconds")
+            self._attrs[ATTR_MANUAL_RUNTIME] = self._manual_preset_runtime
         elif event == EVENT_PROGRAM_CHANGED:
             watering_program = data.get("program")
             lifecycle_phase = data.get("lifecycle_phase")
@@ -625,9 +619,9 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
             else:
                 self._attrs[ATTR_SMART_WATERING_PLAN] = None
 
-    async def _send_station_message(self, station_payload: Any) -> None:
+    async def _send_station_message(self, station_payload):
         try:
-            now = datetime.datetime.now()  # noqa: DTZ005 - be timezone aware?
+            now = datetime.datetime.now()
             iso_time = now.strftime("%Y-%m-%dT%H:%M:%SZ")
 
             payload = {
@@ -645,21 +639,21 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
             raise (err)
 
     @property
-    def entity_picture(self) -> str | None:
+    def entity_picture(self):
         """Return picture of the entity."""
         return self._entity_picture
 
     @property
-    def unique_id(self) -> str:
+    def unique_id(self):
         """Return a unique, unchanging string that represents this switch."""
         return f"{self._mac_address}:{self._device_id}:{self._zone_id}:switch"
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self):
         """Return the status of the sensor."""
         return self._is_on
 
-    async def set_smart_watering_soil_moisture(self, percentage: float) -> None:
+    async def set_smart_watering_soil_moisture(self, percentage):
         """Set the soil moisture percentage for the zone."""
         if self._smart_watering_enabled:
             landscape = None
@@ -717,24 +711,24 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
                 self._zone_name,
             )
 
-    async def start_watering(self, minutes: float) -> None:
-        """Turn on the switch and starts watering."""
+    async def start_watering(self, minutes):
+        """Turns on the switch and starts watering."""
         station_payload = [{"station": self._zone_id, "run_time": minutes}]
         self._is_on = True
         await self._send_station_message(station_payload)
 
-    async def stop_watering(self) -> None:
-        """Turn off the switch and stops watering."""
+    async def stop_watering(self):
+        """Turns off the switch and stops watering."""
         station_payload = []
         self._is_on = False
         await self._send_station_message(station_payload)
 
-    async def async_turn_on(self) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         run_time = self._manual_preset_runtime / 60
         if run_time == 0:
             _LOGGER.warning(
-                "Switch %s manual preset runtime is 0, watering has defaulted to %s minutes. Set the manual run time on your device or please specify number of minutes using the bhyve.start_watering service",  # noqa: E501
+                "Switch %s manual preset runtime is 0, watering has defaulted to %s minutes. Set the manual run time on your device or please specify number of minutes using the bhyve.start_watering service",
                 self._device_name,
                 int(DEFAULT_MANUAL_RUNTIME.seconds / 60),
             )
@@ -742,7 +736,7 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
 
         await self.start_watering(run_time)
 
-    async def async_turn_off(self) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self.stop_watering()
 
@@ -750,9 +744,7 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
 class BHyveRainDelaySwitch(BHyveDeviceEntity, SwitchEntity):
     """Define a BHyve rain delay switch."""
 
-    def __init__(
-        self, hass: HomeAssistant, bhyve: BHyveClient, device: BHyveDevice, icon: str
-    ) -> None:
+    def __init__(self, hass, bhyve, device, icon):
         """Initialize the switch."""
         name = "{} rain delay".format(device.get("name"))
         _LOGGER.info("Creating switch: %s", name)
@@ -762,67 +754,58 @@ class BHyveRainDelaySwitch(BHyveDeviceEntity, SwitchEntity):
 
         super().__init__(hass, bhyve, device, name, icon, SwitchDeviceClass.SWITCH)
 
-    def _setup(self, device: BHyveDevice) -> None:
+    def _setup(self, device):
         self._is_on = False
         self._attrs = {
             "device_id": self._device_id,
         }
         self._available = device.get("is_connected", False)
 
-        device_status = device.get("status", {})
+        device_status = device.get("status")
         rain_delay = device_status.get("rain_delay")
 
         self._update_device_cb = None
         self._extract_rain_delay(rain_delay, device_status)
 
-    def _on_ws_data(self, data: dict) -> None:
-        """
-        Handle websocket data.
-
+    def _on_ws_data(self, data):
+        #
         # {'event': 'rain_delay', 'device_id': 'id', 'delay': 0, 'timestamp': '2020-01-14T12:10:10.000Z'}
-        """  # noqa: E501
+        #
         event = data.get("event")
         if event is None:
             _LOGGER.warning("No event on ws data %s", data)
             return
 
         if event == EVENT_RAIN_DELAY:
-            delay = data.get("delay")
-            if delay is not None:
-                self._extract_rain_delay(
-                    delay, {"rain_delay_started_at": data.get("timestamp")}
-                )
-                # The REST API returns more data about a rain delay
-                # (eg cause/weather_type)
-                self._update_device_soon()
+            self._extract_rain_delay(
+                data.get("delay"), {"rain_delay_started_at": data.get("timestamp")}
+            )
+            # The REST API returns more data about a rain delay (eg cause/weather_type)
+            self._update_device_soon()
 
-    def _should_handle_event(self, event_name: str, _data: dict) -> bool:
+    def _should_handle_event(self, event_name, data):
         return event_name in [EVENT_RAIN_DELAY]
 
-    def _update_device_soon(self) -> None:
+    def _update_device_soon(self):
         if self._update_device_cb is not None:
             self._update_device_cb()  # unsubscribe
         self._update_device_cb = async_call_later(self._hass, 1, self._update_device)
 
-    async def _update_device(self, _time: Any) -> None:
+    async def _update_device(self, time):
         await self._refetch_device(force_update=True)
         self.async_schedule_update_ha_state()
 
-    def _extract_rain_delay(
-        self, rain_delay: int, device_status: dict | None = None
-    ) -> None:
+    def _extract_rain_delay(self, rain_delay, device_status=None):
         if rain_delay is not None and rain_delay > 0:
             self._is_on = True
-            self._attrs: dict[str, Any] = {ATTR_DELAY: rain_delay}
+            self._attrs = {ATTR_DELAY: rain_delay}
             if device_status is not None:
                 self._attrs.update(
                     {
-                        ATTR_CAUSE: device_status.get("rain_delay_cause", "Unknown"),
-                        ATTR_WEATHER_TYPE: device_status.get(
-                            "rain_delay_weather_type", "Unknown"
-                        ),
+                        ATTR_CAUSE: device_status.get("rain_delay_cause"),
+                        ATTR_WEATHER_TYPE: device_status.get("rain_delay_weather_type"),
                         ATTR_STARTED_AT: orbit_time_to_local_time(
-                            device_status.get("rain_delay_started_at", "")
+                            device_status.get("rain_delay_started_at")
                         ),
                     }
                 )
@@ -831,26 +814,26 @@ class BHyveRainDelaySwitch(BHyveDeviceEntity, SwitchEntity):
             self._attrs = {}
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self):
         """Return the status of the sensor."""
         return self._is_on
 
     @property
-    def unique_id(self) -> str:
+    def unique_id(self):
         """Return a unique, unchanging string that represents this sensor."""
         return f"{self._mac_address}:{self._device_id}:rain_delay"
 
     @property
-    def entity_category(self) -> str:
+    def entity_category(self):
         """Rain delay is a configuration category."""
         return EntityCategory.CONFIG
 
-    async def async_turn_on(self) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         self._is_on = True
         await self.enable_rain_delay()
 
-    async def async_turn_off(self) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         self._is_on = False
         await self.disable_rain_delay()

--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -601,7 +601,9 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
             current_station = data.get("current_station")
 
             # Normalize ids
-            if current_station is not None and str(current_station) == str(self._zone_id):
+            if current_station is not None and str(current_station) == str(
+                self._zone_id
+            ):
                 # This is *my* zone running
                 self._is_on = True
                 started_watering_at = data.get("started_watering_station_at")
@@ -614,18 +616,17 @@ class BHyveZoneSwitch(BHyveDeviceEntity, SwitchEntity):
                     current_program,
                     current_runtime,
                 )
-            else:
-                # Only turn off on watering_in_progress if another station is *actually active*
-                if current_station is not None and self._is_on:
-                    if str(current_station) != str(self._zone_id):
-                        _LOGGER.debug(
-                            "%s: Another station (%s) is watering, marking this zone (%s) off",
-                            self.name,
-                            current_station,
-                            self._zone_id,
-                        )
-                        self._is_on = False
-                        self._set_watering_started(None, None, None, None)
+            # Only turn off on watering_in_progress if another station is active
+            elif current_station is not None and self._is_on:
+                if str(current_station) != str(self._zone_id):
+                    _LOGGER.debug(
+                        "%s: Another station (%s) is watering, marking this zone (%s) off",  # noqa: E501
+                        self.name,
+                        current_station,
+                        self._zone_id,
+                    )
+                    self._is_on = False
+                    self._set_watering_started(None, None, None, None)
         elif event == EVENT_SET_MANUAL_PRESET_TIME:
             manual_preset_runtime = data.get("seconds")
             if manual_preset_runtime is not None:


### PR DESCRIPTION
When operating in smart zone mode, Home Assistant would show that each zone would turn on at the correct time, but it would not turn off a zone when the next zone started. This is wrong as this system does not run more than one zone at a time. This PR fixes this bug.
Here is a screenshot from home assistant before the fix:
<img width="1075" height="2393" alt="Screenshot_Bug" src="https://github.com/user-attachments/assets/cfa02234-27a3-4a79-bdf0-9843fd112ffc" />
Here is a screenshot after the fix:
<img width="1075" height="2393" alt="Screenshot_Fixed" src="https://github.com/user-attachments/assets/2cbb1639-e333-4663-85b0-e0b4a167daff" />
