### PR TITLE
Smart watering switch and program improvements

### DIFF
--- a/custom_components/bhyve/coordinator.py
+++ b/custom_components/bhyve/coordinator.py
@@ -327,18 +327,22 @@ class BHyveDataUpdateCoordinator(DataUpdateCoordinator):
             self.async_set_updated_data(self.data)
             return
 
-        # Handle program deletion
-        if lifecycle_phase == "delete":
-            if program_id in self.data["programs"]:
+        # Handle program deletion (smart programs use "destroy" but should
+        # be kept as entities since they are toggled via water_sense_mode)
+        if lifecycle_phase in ("delete", "destroy"):
+            is_smart = (
+                self.data["programs"].get(program_id, {}).get("is_smart_program", False)
+            )
+            if not is_smart and program_id in self.data["programs"]:
                 _LOGGER.debug("Removing program %s from coordinator data", program_id)
                 del self.data["programs"][program_id]
-                # Fire an event so the switch platform can remove the entity
                 self.hass.bus.async_fire(
                     "bhyve_program_deleted",
                     {"program_id": program_id},
                 )
-            self.async_set_updated_data(self.data)
-            return
+                self.async_set_updated_data(self.data)
+                return
+            # Smart program "destroy" falls through to update the program data
 
         # For update events, check if program exists
         if program_id not in self.data["programs"]:

--- a/custom_components/bhyve/coordinator.py
+++ b/custom_components/bhyve/coordinator.py
@@ -335,7 +335,7 @@ class BHyveDataUpdateCoordinator(DataUpdateCoordinator):
                 _LOGGER.debug("Adding new program %s to coordinator data", program_id)
                 self.data["programs"][program_id] = program_data
                 if program_data.get("is_smart_program"):
-                    # Smart program created means water_sense_mode turned on
+                    # Smart program created means smart watering was enabled
                     device_id = event_data.get("device_id")
                     self._set_zones_smart_watering(device_id, enabled=True)
                 else:
@@ -347,7 +347,7 @@ class BHyveDataUpdateCoordinator(DataUpdateCoordinator):
             return
 
         # Handle program deletion (smart programs use "destroy" but should
-        # be kept as entities since they are toggled via water_sense_mode)
+        # be kept as entities since they represent a toggle, not a removal)
         if lifecycle_phase in ("delete", "destroy"):
             is_smart = (
                 self.data["programs"].get(program_id, {}).get("is_smart_program", False)
@@ -362,7 +362,7 @@ class BHyveDataUpdateCoordinator(DataUpdateCoordinator):
                 self.async_set_updated_data(self.data)
                 return
             if is_smart:
-                # Smart program destroy means water_sense_mode was turned off.
+                # Smart program destroy means smart watering was disabled.
                 # Update zone data so smart watering switches reflect the change.
                 device_id = event_data.get("device_id")
                 self._set_zones_smart_watering(device_id, enabled=False)

--- a/custom_components/bhyve/coordinator.py
+++ b/custom_components/bhyve/coordinator.py
@@ -295,6 +295,26 @@ class BHyveDataUpdateCoordinator(DataUpdateCoordinator):
         # Notify all listening entities
         self.async_set_updated_data(self.data)
 
+    def _set_zones_smart_watering(
+        self, device_id: str | None, *, enabled: bool
+    ) -> None:
+        """Update smart_watering_enabled on all zones of a device."""
+        if not device_id:
+            return
+        device_data = self.data.get("devices", {}).get(device_id, {})
+        device = device_data.get("device", {})
+        for zone in device.get("zones", []):
+            zone["smart_watering_enabled"] = enabled
+
+    @staticmethod
+    def _get_program_id(event_data: dict[str, Any]) -> str | None:
+        """Extract program ID from event data."""
+        program_id = event_data.get("program_id")
+        if not program_id:
+            program = event_data.get("program", {})
+            program_id = program.get("id") if isinstance(program, dict) else None
+        return program_id
+
     async def async_handle_program_event(self, event_data: dict[str, Any]) -> None:
         """Handle WebSocket program events."""
         if not self.data:
@@ -302,12 +322,7 @@ class BHyveDataUpdateCoordinator(DataUpdateCoordinator):
             return
 
         lifecycle_phase = event_data.get("lifecycle_phase")
-        program_id = event_data.get("program_id")
-
-        if not program_id:
-            # Some program events have program in a different structure
-            program = event_data.get("program", {})
-            program_id = program.get("id") if isinstance(program, dict) else None
+        program_id = self._get_program_id(event_data)
 
         if not program_id:
             _LOGGER.debug("No program_id found in event, ignoring")
@@ -319,11 +334,15 @@ class BHyveDataUpdateCoordinator(DataUpdateCoordinator):
             if isinstance(program_data, dict):
                 _LOGGER.debug("Adding new program %s to coordinator data", program_id)
                 self.data["programs"][program_id] = program_data
-                # Fire an event so the switch platform can create a new entity
-                self.hass.bus.async_fire(
-                    "bhyve_program_created",
-                    {"program_id": program_id, "program": program_data},
-                )
+                if program_data.get("is_smart_program"):
+                    # Smart program created means water_sense_mode turned on
+                    device_id = event_data.get("device_id")
+                    self._set_zones_smart_watering(device_id, enabled=True)
+                else:
+                    self.hass.bus.async_fire(
+                        "bhyve_program_created",
+                        {"program_id": program_id, "program": program_data},
+                    )
             self.async_set_updated_data(self.data)
             return
 
@@ -342,7 +361,12 @@ class BHyveDataUpdateCoordinator(DataUpdateCoordinator):
                 )
                 self.async_set_updated_data(self.data)
                 return
-            # Smart program "destroy" falls through to update the program data
+            if is_smart:
+                # Smart program destroy means water_sense_mode was turned off.
+                # Update zone data so smart watering switches reflect the change.
+                device_id = event_data.get("device_id")
+                self._set_zones_smart_watering(device_id, enabled=False)
+                # Fall through to update the program data
 
         # For update events, check if program exists
         if program_id not in self.data["programs"]:

--- a/custom_components/bhyve/pybhyve/client.py
+++ b/custom_components/bhyve/pybhyve/client.py
@@ -249,6 +249,13 @@ class BHyveClient:
         json = {"sprinkler_timer_program": program}
         await self._request("put", path, json=json)
 
+    async def update_device(self, device: dict) -> None:
+        """Update device settings."""
+        device_id = device.get("id")
+        path = f"{DEVICES_PATH}/{device_id}"
+        json = {"device": device}
+        await self._request("put", path, json=json)
+
     async def send_message(self, payload: Any) -> None:
         """Send a message via the websocket."""
         if self._websocket is not None:

--- a/custom_components/bhyve/pybhyve/websocket.py
+++ b/custom_components/bhyve/pybhyve/websocket.py
@@ -124,8 +124,20 @@ class OrbitWebsocket:
 
                         if msg.type == WSMsgType.TEXT:
                             data = json.loads(msg.data)
+                            log_data = data
+                            if (
+                                isinstance(data.get("program"), dict)
+                                and "watering_plan" in data["program"]
+                            ):
+                                log_data = {
+                                    **data,
+                                    "program": {
+                                        **data["program"],
+                                        "watering_plan": "<removed>",
+                                    },
+                                }
                             _LOGGER.debug(
-                                "msg received:\n%s", json.dumps(data, indent=2)
+                                "msg received:\n%s", json.dumps(log_data, indent=2)
                             )
                             task = ensure_future(self._async_callback(data))
                             # Add task to the set to create a strong reference, and

--- a/custom_components/bhyve/strings.json
+++ b/custom_components/bhyve/strings.json
@@ -182,6 +182,9 @@
       },
       "program": {
         "name": "{program_name} program"
+      },
+      "smart_watering": {
+        "name": "{zone_name} smart watering"
       }
     },
     "valve": {

--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -64,6 +64,20 @@ ATTR_STARTED_AT = "started_at"
 
 ATTR_PROGRAM = "program_{}"
 
+# Keys accepted by the B-hyve API for program updates
+PROGRAM_UPDATE_KEYS = {
+    "budget",
+    "device_id",
+    "enabled",
+    "frequency",
+    "id",
+    "name",
+    "program",
+    "program_start_date",
+    "run_times",
+    "start_times",
+}
+
 
 @dataclass(frozen=True, kw_only=True)
 class BHyveSwitchEntityDescription(SwitchEntityDescription):
@@ -227,9 +241,7 @@ class BHyveProgramSwitch(BHyveCoordinatorEntity, SwitchEntity):
                 }
             )
         else:
-            program = BHyveTimerProgram(self.program_data)
-            program["enabled"] = True
-            await self.coordinator.client.update_program(self._program_id, program)
+            await self._update_program(enabled=True)
 
     async def async_turn_off(self, **_kwargs: Any) -> None:
         """Turn the switch off."""
@@ -243,9 +255,15 @@ class BHyveProgramSwitch(BHyveCoordinatorEntity, SwitchEntity):
                 }
             )
         else:
-            program = BHyveTimerProgram(self.program_data)
-            program["enabled"] = False
-            await self.coordinator.client.update_program(self._program_id, program)
+            await self._update_program(enabled=False)
+
+    async def _update_program(self, *, enabled: bool) -> None:
+        """Update a non-smart program via the API."""
+        program = BHyveTimerProgram(
+            {k: v for k, v in self.program_data.items() if k in PROGRAM_UPDATE_KEYS}
+        )
+        program["enabled"] = enabled
+        await self.coordinator.client.update_program(self._program_id, program)
 
     async def start_program(self) -> None:
         """Begins running a program."""

--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -328,27 +328,25 @@ class BHyveSmartWateringSwitch(BHyveCoordinatorEntity, SwitchEntity):
         """Return true if smart watering is enabled for this zone."""
         return self._get_zone_data().get("smart_watering_enabled", False)
 
+    async def _set_smart_watering(self, *, enabled: bool) -> None:
+        """Update the zone's smart_watering_enabled on the device."""
+        zones = [
+            {**z, "smart_watering_enabled": enabled}
+            if z.get("station") == self._zone_id
+            else z
+            for z in self.device_data.get("zones", [])
+        ]
+        await self.coordinator.client.update_device(
+            {"id": self._device_id, "zones": zones}
+        )
+
     async def async_turn_on(self, **_kwargs: Any) -> None:
         """Turn smart watering on."""
-        await self.coordinator.client.update_device(
-            {
-                "id": self._device_id,
-                "type": self._device_type,
-                "mac_address": self._mac_address,
-                "water_sense_mode": "auto",
-            }
-        )
+        await self._set_smart_watering(enabled=True)
 
     async def async_turn_off(self, **_kwargs: Any) -> None:
         """Turn smart watering off."""
-        await self.coordinator.client.update_device(
-            {
-                "id": self._device_id,
-                "type": self._device_type,
-                "mac_address": self._mac_address,
-                "water_sense_mode": "off",
-            }
-        )
+        await self._set_smart_watering(enabled=False)
 
 
 class BHyveRainDelaySwitch(BHyveCoordinatorEntity, SwitchEntity):

--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -217,17 +217,35 @@ class BHyveProgramSwitch(BHyveCoordinatorEntity, SwitchEntity):
 
     async def async_turn_on(self, **_kwargs: Any) -> None:
         """Turn the switch on."""
-        program = BHyveTimerProgram(self.program_data)
-        program["enabled"] = True
-        await self.coordinator.client.update_program(self._program_id, program)
-        # Coordinator updates via WebSocket event
+        if self.program_data.get("is_smart_program"):
+            await self.coordinator.client.update_device(
+                {
+                    "id": self._device_id,
+                    "type": self._device_type,
+                    "mac_address": self._mac_address,
+                    "water_sense_mode": "auto",
+                }
+            )
+        else:
+            program = BHyveTimerProgram(self.program_data)
+            program["enabled"] = True
+            await self.coordinator.client.update_program(self._program_id, program)
 
     async def async_turn_off(self, **_kwargs: Any) -> None:
         """Turn the switch off."""
-        program = BHyveTimerProgram(self.program_data)
-        program["enabled"] = False
-        await self.coordinator.client.update_program(self._program_id, program)
-        # Coordinator updates via WebSocket event
+        if self.program_data.get("is_smart_program"):
+            await self.coordinator.client.update_device(
+                {
+                    "id": self._device_id,
+                    "type": self._device_type,
+                    "mac_address": self._mac_address,
+                    "water_sense_mode": "off",
+                }
+            )
+        else:
+            program = BHyveTimerProgram(self.program_data)
+            program["enabled"] = False
+            await self.coordinator.client.update_program(self._program_id, program)
 
     async def start_program(self) -> None:
         """Begins running a program."""

--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -144,8 +144,23 @@ async def async_setup_entry(
                 )
             )
 
-    # Create program switches
+            # Create smart watering switches for zones that support it
+            smart_watering_desc = BHyveSwitchEntityDescription(
+                key="smart_watering",
+                translation_key="smart_watering",
+                icon="mdi:auto-fix",
+                entity_category=EntityCategory.CONFIG,
+            )
+            switches.extend(
+                BHyveSmartWateringSwitch(coordinator, device, zone, smart_watering_desc)
+                for zone in device.get("zones", [])
+                if zone.get("smart_watering_enabled") is not None
+            )
+
+    # Create program switches (skip smart programs, handled above)
     for program in coordinator.data.get("programs", {}).values():
+        if program.get("is_smart_program"):
+            continue
         program_device = device_by_id.get(program.get("device_id"))
         if program_device is not None:
             _LOGGER.info("Creating switch: Program %s", program.get("name"))
@@ -159,7 +174,7 @@ async def async_setup_entry(
     async def async_handle_program_created(event: Any) -> None:
         """Handle creation of new programs."""
         program = event.data.get("program")
-        if not program:
+        if not program or program.get("is_smart_program"):
             return
 
         program_device = device_by_id.get(program.get("device_id"))
@@ -231,31 +246,11 @@ class BHyveProgramSwitch(BHyveCoordinatorEntity, SwitchEntity):
 
     async def async_turn_on(self, **_kwargs: Any) -> None:
         """Turn the switch on."""
-        if self.program_data.get("is_smart_program"):
-            await self.coordinator.client.update_device(
-                {
-                    "id": self._device_id,
-                    "type": self._device_type,
-                    "mac_address": self._mac_address,
-                    "water_sense_mode": "auto",
-                }
-            )
-        else:
-            await self._update_program(enabled=True)
+        await self._update_program(enabled=True)
 
     async def async_turn_off(self, **_kwargs: Any) -> None:
         """Turn the switch off."""
-        if self.program_data.get("is_smart_program"):
-            await self.coordinator.client.update_device(
-                {
-                    "id": self._device_id,
-                    "type": self._device_type,
-                    "mac_address": self._mac_address,
-                    "water_sense_mode": "off",
-                }
-            )
-        else:
-            await self._update_program(enabled=False)
+        await self._update_program(enabled=False)
 
     async def _update_program(self, *, enabled: bool) -> None:
         """Update a non-smart program via the API."""
@@ -289,6 +284,71 @@ class BHyveProgramSwitch(BHyveCoordinatorEntity, SwitchEntity):
         except BHyveError as err:
             _LOGGER.warning("Failed to send to BHyve websocket message %s", err)
             raise
+
+
+class BHyveSmartWateringSwitch(BHyveCoordinatorEntity, SwitchEntity):
+    """Define a BHyve smart watering switch for a zone."""
+
+    entity_description: BHyveSwitchEntityDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: BHyveDataUpdateCoordinator,
+        device: BHyveDevice,
+        zone: dict,
+        description: BHyveSwitchEntityDescription,
+    ) -> None:
+        """Initialize the switch."""
+        self.entity_description = description
+        self._zone_id = zone.get("station")
+        zone_name = zone.get("name", "")
+        all_zones = device.get("zones", [])
+        if zone_name and zone_name != device.get("name") and len(all_zones) > 1:
+            self._attr_name = f"{zone_name} smart watering"
+        else:
+            self._attr_name = "Smart watering"
+        self._attr_translation_placeholders = {"zone_name": zone_name}
+
+        super().__init__(coordinator, device)
+
+        self._attr_unique_id = (
+            f"{self._mac_address}:{self._device_id}:{self._zone_id}:smart_watering"
+        )
+
+    def _get_zone_data(self) -> dict:
+        """Get current zone data from coordinator."""
+        for zone in self.device_data.get("zones", []):
+            if zone.get("station") == self._zone_id:
+                return zone
+        return {}
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if smart watering is enabled for this zone."""
+        return self._get_zone_data().get("smart_watering_enabled", False)
+
+    async def async_turn_on(self, **_kwargs: Any) -> None:
+        """Turn smart watering on."""
+        await self.coordinator.client.update_device(
+            {
+                "id": self._device_id,
+                "type": self._device_type,
+                "mac_address": self._mac_address,
+                "water_sense_mode": "auto",
+            }
+        )
+
+    async def async_turn_off(self, **_kwargs: Any) -> None:
+        """Turn smart watering off."""
+        await self.coordinator.client.update_device(
+            {
+                "id": self._device_id,
+                "type": self._device_type,
+                "mac_address": self._mac_address,
+                "water_sense_mode": "off",
+            }
+        )
 
 
 class BHyveRainDelaySwitch(BHyveCoordinatorEntity, SwitchEntity):

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1111,8 +1111,8 @@ class TestBHyveSmartWateringSwitch:
         assert switch_on.is_on is True
         assert switch_off.is_on is False
 
-    async def test_turn_on_calls_update_device(self) -> None:
-        """Test turning on sends water_sense_mode auto."""
+    async def test_turn_on_patches_zone(self) -> None:
+        """Test turning on sets smart_watering_enabled on the zone."""
         device = BHyveDevice(
             {
                 "id": "device-4",
@@ -1125,11 +1125,13 @@ class TestBHyveSmartWateringSwitch:
                 "status": {"run_mode": "auto"},
                 "zones": [
                     {"station": 1, "smart_watering_enabled": False},
+                    {"station": 2, "smart_watering_enabled": False},
                 ],
             }
         )
         coordinator = create_mock_coordinator(
-            {"device-4": {"device": device, "history": [], "landscapes": {}}}, {}
+            {"device-4": {"device": device, "history": [], "landscapes": {}}},
+            {},
         )
         switch = self._create_switch(device, device["zones"][0], coordinator)
 
@@ -1137,10 +1139,15 @@ class TestBHyveSmartWateringSwitch:
         coordinator.client.update_device.assert_called_once()
         call_args = coordinator.client.update_device.call_args[0][0]
         assert call_args["id"] == "device-4"
-        assert call_args["water_sense_mode"] == "auto"
+        # Zone 1 should be enabled, zone 2 unchanged
+        zones = call_args["zones"]
+        assert zones[0]["station"] == 1
+        assert zones[0]["smart_watering_enabled"] is True
+        assert zones[1]["station"] == 2
+        assert zones[1]["smart_watering_enabled"] is False
 
-    async def test_turn_off_calls_update_device(self) -> None:
-        """Test turning off sends water_sense_mode off."""
+    async def test_turn_off_patches_zone(self) -> None:
+        """Test turning off sets smart_watering_enabled false on the zone."""
         device = BHyveDevice(
             {
                 "id": "device-4",
@@ -1153,18 +1160,23 @@ class TestBHyveSmartWateringSwitch:
                 "status": {"run_mode": "auto"},
                 "zones": [
                     {"station": 1, "smart_watering_enabled": True},
+                    {"station": 2, "smart_watering_enabled": True},
                 ],
             }
         )
         coordinator = create_mock_coordinator(
-            {"device-4": {"device": device, "history": [], "landscapes": {}}}, {}
+            {"device-4": {"device": device, "history": [], "landscapes": {}}},
+            {},
         )
         switch = self._create_switch(device, device["zones"][0], coordinator)
 
         await switch.async_turn_off()
         coordinator.client.update_device.assert_called_once()
         call_args = coordinator.client.update_device.call_args[0][0]
-        assert call_args["water_sense_mode"] == "off"
+        zones = call_args["zones"]
+        # Zone 1 should be disabled, zone 2 unchanged
+        assert zones[0]["smart_watering_enabled"] is False
+        assert zones[1]["smart_watering_enabled"] is True
 
     async def test_setup_creates_per_zone_switches(self, hass: HomeAssistant) -> None:
         """Test setup creates one smart watering switch per zone."""

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -37,6 +37,7 @@ def create_mock_coordinator(devices: dict, programs: dict) -> MagicMock:
     coordinator.client = MagicMock()
     coordinator.client.send_message = AsyncMock()
     coordinator.client.update_program = AsyncMock()
+    coordinator.client.update_device = AsyncMock()
     return coordinator
 
 
@@ -412,14 +413,14 @@ class TestBHyveProgramSwitch:
             description=description,
         )
 
-        # Turn on the switch
+        # Turn on the switch (smart program uses update_device)
         await switch.async_turn_on()
 
-        # Verify update_program was called with enabled=True
-        coordinator.client.update_program.assert_called_once()
-        call_args = coordinator.client.update_program.call_args[0]
-        assert call_args[0] == TEST_PROGRAM_ID
-        assert call_args[1]["enabled"] is True
+        # Verify update_device was called with water_sense_mode=auto
+        coordinator.client.update_device.assert_called_once()
+        call_args = coordinator.client.update_device.call_args[0][0]
+        assert call_args["id"] == TEST_DEVICE_ID
+        assert call_args["water_sense_mode"] == "auto"
 
     async def test_program_switch_turn_off(
         self,

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -13,6 +13,7 @@ from custom_components.bhyve.pybhyve.typings import BHyveDevice, BHyveTimerProgr
 from custom_components.bhyve.switch import (
     BHyveProgramSwitch,
     BHyveRainDelaySwitch,
+    BHyveSmartWateringSwitch,
     BHyveSwitchEntityDescription,
     async_setup_entry,
 )
@@ -151,7 +152,7 @@ def mock_timer_program_disabled() -> BHyveTimerProgram:
             "name": "Evening Schedule",
             "program": "b",
             "enabled": False,
-            "is_smart_program": True,
+            "is_smart_program": False,
             "frequency": {"type": "days", "days": [6, 0]},
             "start_times": ["18:00"],
             "budget": 85,
@@ -413,14 +414,14 @@ class TestBHyveProgramSwitch:
             description=description,
         )
 
-        # Turn on the switch (smart program uses update_device)
+        # Turn on the switch
         await switch.async_turn_on()
 
-        # Verify update_device was called with water_sense_mode=auto
-        coordinator.client.update_device.assert_called_once()
-        call_args = coordinator.client.update_device.call_args[0][0]
-        assert call_args["id"] == TEST_DEVICE_ID
-        assert call_args["water_sense_mode"] == "auto"
+        # Verify update_program was called with enabled=True
+        coordinator.client.update_program.assert_called_once()
+        call_args = coordinator.client.update_program.call_args[0]
+        assert call_args[0] == TEST_PROGRAM_ID
+        assert call_args[1]["enabled"] is True
 
     async def test_program_switch_turn_off(
         self,
@@ -971,3 +972,283 @@ class TestSwitchEdgeCases:
         # (coordinator ensures data structure is always present)
         assert program_switch.is_on is True
         assert rain_delay_switch.is_on is False
+
+
+class TestBHyveSmartWateringSwitch:
+    """Test BHyveSmartWateringSwitch entity."""
+
+    @staticmethod
+    def _create_switch(
+        device: BHyveDevice, zone: dict, coordinator: MagicMock | None = None
+    ) -> BHyveSmartWateringSwitch:
+        if coordinator is None:
+            coordinator = create_mock_coordinator(
+                {
+                    device["id"]: {
+                        "device": device,
+                        "history": [],
+                        "landscapes": {},
+                    }
+                },
+                {},
+            )
+        return BHyveSmartWateringSwitch(
+            coordinator=coordinator,
+            device=device,
+            zone=zone,
+            description=BHyveSwitchEntityDescription(
+                key="smart_watering",
+                translation_key="smart_watering",
+                icon="mdi:auto-fix",
+                entity_category=EntityCategory.CONFIG,
+            ),
+        )
+
+    async def test_single_zone_device_name(self) -> None:
+        """Test smart watering switch name for single-zone device."""
+        device = BHyveDevice(
+            {
+                "id": "device-1",
+                "name": "Street Lawn",
+                "type": "sprinkler_timer",
+                "mac_address": "aa:bb:cc:dd:ee:01",
+                "hardware_version": "HT25-0000",
+                "firmware_version": "0085",
+                "is_connected": True,
+                "status": {"run_mode": "auto"},
+                "zones": [
+                    {"station": 1, "smart_watering_enabled": True},
+                ],
+            }
+        )
+        switch = self._create_switch(device, device["zones"][0])
+        assert switch._attr_name == "Smart watering"
+
+    async def test_multi_zone_device_names(self) -> None:
+        """Test smart watering switch names for multi-zone device."""
+        device = BHyveDevice(
+            {
+                "id": "device-2",
+                "name": "Dover Gardens",
+                "type": "sprinkler_timer",
+                "mac_address": "aa:bb:cc:dd:ee:02",
+                "hardware_version": "WT25G2-0001",
+                "firmware_version": "0087",
+                "is_connected": True,
+                "status": {"run_mode": "auto"},
+                "zones": [
+                    {
+                        "station": 1,
+                        "name": "Front Garden",
+                        "smart_watering_enabled": True,
+                    },
+                    {
+                        "station": 2,
+                        "name": "Back Garden",
+                        "smart_watering_enabled": True,
+                    },
+                    {
+                        "station": 3,
+                        "name": "Side Garden",
+                        "smart_watering_enabled": False,
+                    },
+                ],
+            }
+        )
+        switch_1 = self._create_switch(device, device["zones"][0])
+        switch_2 = self._create_switch(device, device["zones"][1])
+        switch_3 = self._create_switch(device, device["zones"][2])
+
+        assert switch_1._attr_name == "Front Garden smart watering"
+        assert switch_2._attr_name == "Back Garden smart watering"
+        assert switch_3._attr_name == "Side Garden smart watering"
+
+        # Unique IDs include station
+        assert "1:smart_watering" in switch_1.unique_id
+        assert "2:smart_watering" in switch_2.unique_id
+        assert "3:smart_watering" in switch_3.unique_id
+
+    async def test_is_on_reads_zone_data(self) -> None:
+        """Test is_on reflects the zone's smart_watering_enabled value."""
+        device = BHyveDevice(
+            {
+                "id": "device-3",
+                "name": "Monash",
+                "type": "sprinkler_timer",
+                "mac_address": "aa:bb:cc:dd:ee:03",
+                "hardware_version": "WT25G2-0001",
+                "firmware_version": "0087",
+                "is_connected": True,
+                "status": {"run_mode": "auto"},
+                "zones": [
+                    {
+                        "station": 1,
+                        "name": "Front Lawn",
+                        "smart_watering_enabled": True,
+                    },
+                    {
+                        "station": 2,
+                        "name": "Back Lawn",
+                        "smart_watering_enabled": False,
+                    },
+                ],
+            }
+        )
+        coordinator = create_mock_coordinator(
+            {
+                "device-3": {
+                    "device": device,
+                    "history": [],
+                    "landscapes": {},
+                }
+            },
+            {},
+        )
+
+        switch_on = self._create_switch(device, device["zones"][0], coordinator)
+        switch_off = self._create_switch(device, device["zones"][1], coordinator)
+
+        assert switch_on.is_on is True
+        assert switch_off.is_on is False
+
+    async def test_turn_on_calls_update_device(self) -> None:
+        """Test turning on sends water_sense_mode auto."""
+        device = BHyveDevice(
+            {
+                "id": "device-4",
+                "name": "Test",
+                "type": "sprinkler_timer",
+                "mac_address": "aa:bb:cc:dd:ee:04",
+                "hardware_version": "HT25-0000",
+                "firmware_version": "0085",
+                "is_connected": True,
+                "status": {"run_mode": "auto"},
+                "zones": [
+                    {"station": 1, "smart_watering_enabled": False},
+                ],
+            }
+        )
+        coordinator = create_mock_coordinator(
+            {"device-4": {"device": device, "history": [], "landscapes": {}}}, {}
+        )
+        switch = self._create_switch(device, device["zones"][0], coordinator)
+
+        await switch.async_turn_on()
+        coordinator.client.update_device.assert_called_once()
+        call_args = coordinator.client.update_device.call_args[0][0]
+        assert call_args["id"] == "device-4"
+        assert call_args["water_sense_mode"] == "auto"
+
+    async def test_turn_off_calls_update_device(self) -> None:
+        """Test turning off sends water_sense_mode off."""
+        device = BHyveDevice(
+            {
+                "id": "device-4",
+                "name": "Test",
+                "type": "sprinkler_timer",
+                "mac_address": "aa:bb:cc:dd:ee:04",
+                "hardware_version": "HT25-0000",
+                "firmware_version": "0085",
+                "is_connected": True,
+                "status": {"run_mode": "auto"},
+                "zones": [
+                    {"station": 1, "smart_watering_enabled": True},
+                ],
+            }
+        )
+        coordinator = create_mock_coordinator(
+            {"device-4": {"device": device, "history": [], "landscapes": {}}}, {}
+        )
+        switch = self._create_switch(device, device["zones"][0], coordinator)
+
+        await switch.async_turn_off()
+        coordinator.client.update_device.assert_called_once()
+        call_args = coordinator.client.update_device.call_args[0][0]
+        assert call_args["water_sense_mode"] == "off"
+
+    async def test_setup_creates_per_zone_switches(self, hass: HomeAssistant) -> None:
+        """Test setup creates one smart watering switch per zone."""
+        device = BHyveDevice(
+            {
+                "id": "dover-gardens",
+                "name": "Dover Gardens",
+                "type": "sprinkler_timer",
+                "mac_address": "4467550a3f05",
+                "hardware_version": "WT25G2-0001",
+                "firmware_version": "0087",
+                "is_connected": True,
+                "smart_watering_enabled": True,
+                "status": {
+                    "run_mode": "auto",
+                    "watering_status": None,
+                },
+                "zones": [
+                    {
+                        "station": 1,
+                        "name": "Front Garden",
+                        "smart_watering_enabled": True,
+                    },
+                    {
+                        "station": 2,
+                        "name": "Front Garden by House",
+                        "smart_watering_enabled": True,
+                    },
+                    {
+                        "station": 3,
+                        "name": "Back Garden West",
+                        "smart_watering_enabled": True,
+                    },
+                    {
+                        "station": 4,
+                        "name": "Back Garden Middle",
+                        "smart_watering_enabled": True,
+                    },
+                    {
+                        "station": 5,
+                        "name": "Back Garden East",
+                        "smart_watering_enabled": True,
+                    },
+                ],
+            }
+        )
+
+        coordinator = create_mock_coordinator(
+            {
+                "dover-gardens": {
+                    "device": device,
+                    "history": [],
+                    "landscapes": {},
+                }
+            },
+            {},
+        )
+
+        hass.data = {
+            "bhyve": {
+                "test_entry_id": {
+                    "coordinator": coordinator,
+                    "devices": [device],
+                }
+            }
+        }
+
+        entry = MagicMock(spec=ConfigEntry)
+        entry.entry_id = "test_entry_id"
+        entry.options = {}
+        entry.async_on_unload = lambda _cb: None
+
+        added_entities: list = []
+
+        def track_add(entities: list) -> None:
+            added_entities.extend(entities)
+
+        await async_setup_entry(hass, entry, MagicMock(side_effect=track_add))
+
+        smart_switches = [
+            e for e in added_entities if isinstance(e, BHyveSmartWateringSwitch)
+        ]
+        assert len(smart_switches) == 5
+
+        names = [s._attr_name for s in smart_switches]
+        assert "Front Garden smart watering" in names
+        assert "Back Garden West smart watering" in names


### PR DESCRIPTION
## Summary
- Add per-zone `BHyveSmartWateringSwitch` for devices with smart watering support, created from device/zone data rather than the programs API
- Smart watering on/off patches the zone's `smart_watering_enabled` field via the device API
- Coordinator syncs zone `smart_watering_enabled` when smart program create/destroy websocket events are received
- Smart program "destroy" events keep the entity (not deleted) since they represent a toggle, not a removal
- Non-smart program updates now only send the required API keys
- Strip `watering_plan` from websocket debug logs to reduce noise
- Skip smart programs in regular `BHyveProgramSwitch` creation

## Test plan
- [x] All 117 tests pass, 5 skipped
- [x] Linting passes
- [ ] Verify smart watering switch toggles correctly for single-zone devices
- [ ] Verify smart watering switch toggles correctly for multi-zone devices
- [ ] Verify state syncs when toggled from B-hyve app