### PR TITLE
Add bridge device support

### DIFF
--- a/custom_components/bhyve/__init__.py
+++ b/custom_components/bhyve/__init__.py
@@ -18,7 +18,7 @@ from homeassistant.exceptions import (
 )
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -26,6 +26,7 @@ from custom_components.bhyve.pybhyve.typings import BHyveDevice
 
 from .const import (
     CONF_DEVICES,
+    DEVICE_BRIDGE,
     DOMAIN,
     EVENT_PROGRAM_CHANGED,
     LOGGER,
@@ -103,6 +104,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     programs = await client.timer_programs
     devices = filter_configured_devices(entry, all_devices)
 
+    # Build a mapping from device_gateway_topic to bridge device ID
+    # so child devices can reference their bridge via via_device.
+    # Bridges are always included by filter_configured_devices.
+    gateway_to_bridge: dict[str, str] = {}
+    for device in devices:
+        if device.get("type") == DEVICE_BRIDGE:
+            gateway_topic = device.get("device_gateway_topic")
+            if gateway_topic:
+                gateway_to_bridge[gateway_topic] = device.get("id", "")
+    coordinator.gateway_to_bridge = gateway_to_bridge
+
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         "client": client,
         "coordinator": coordinator,
@@ -146,9 +158,12 @@ async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
             # Get currently configured device IDs
             configured_ids = set(entry.options.get(CONF_DEVICES, []))
 
-            # Find devices that were removed from configuration
-            all_device_ids = {str(d["id"]) for d in all_devices}
-            removed_device_ids = all_device_ids - configured_ids
+            # Find leaf devices that were removed from configuration
+            # (bridges are always included and not user-selectable)
+            leaf_device_ids = {
+                str(d["id"]) for d in all_devices if d.get("type") != DEVICE_BRIDGE
+            }
+            removed_device_ids = leaf_device_ids - configured_ids
 
             if removed_device_ids:
                 # Remove devices from Home Assistant
@@ -183,8 +198,16 @@ class BHyveCoordinatorEntity(CoordinatorEntity[BHyveDataUpdateCoordinator]):
         self._mac_address = device.get("mac_address")
 
         # Device info for grouping
-        self._attr_device_info = DeviceInfo(
+        connections: set[tuple[str, str]] = set()
+        if self._mac_address:
+            # Format raw MAC (e.g. "4467552a366e") with colons
+            raw = self._mac_address.replace(":", "").replace("-", "").lower()
+            formatted_mac = ":".join(raw[i : i + 2] for i in range(0, len(raw), 2))
+            connections.add((CONNECTION_NETWORK_MAC, formatted_mac))
+
+        device_info = DeviceInfo(
             identifiers={(DOMAIN, self._device_id)},
+            connections=connections,
             manufacturer=MANUFACTURER,
             configuration_url=f"https://techsupport.orbitbhyve.com/dashboard/support/device/{self._device_id}",
             name=self._device_name,
@@ -192,6 +215,16 @@ class BHyveCoordinatorEntity(CoordinatorEntity[BHyveDataUpdateCoordinator]):
             hw_version=device.get("hardware_version"),
             sw_version=device.get("firmware_version"),
         )
+
+        # Link non-bridge devices to their bridge via device_gateway_topic
+        if self._device_type != DEVICE_BRIDGE:
+            gateway_topic = device.get("device_gateway_topic")
+            gateway_to_bridge = getattr(coordinator, "gateway_to_bridge", {})
+            bridge_id = gateway_to_bridge.get(gateway_topic) if gateway_topic else None
+            if bridge_id:
+                device_info["via_device"] = (DOMAIN, bridge_id)
+
+        self._attr_device_info = device_info
 
         LOGGER.debug(
             "Creating %s: %s - %s",

--- a/custom_components/bhyve/binary_sensor.py
+++ b/custom_components/bhyve/binary_sensor.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -13,7 +12,7 @@ from homeassistant.components.binary_sensor import (
 )
 
 from . import BHyveCoordinatorEntity
-from .const import DEVICE_FLOOD, DEVICE_SPRINKLER, DOMAIN
+from .const import DEVICE_BRIDGE, DEVICE_FLOOD, DEVICE_SPRINKLER, DOMAIN
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -22,8 +21,6 @@ if TYPE_CHECKING:
 
     from .coordinator import BHyveDataUpdateCoordinator
     from .pybhyve.typings import BHyveDevice
-
-_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -83,6 +80,15 @@ BINARY_SENSOR_TYPES: tuple[BHyveBinarySensorEntityDescription, ...] = (
         attributes_fn=lambda data: {
             "station_faults": data.get("status", {}).get("station_faults", []),
         },
+    ),
+    BHyveBinarySensorEntityDescription(
+        key="connectivity",
+        translation_key="connectivity",
+        name="Connected",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        unique_id_suffix="connectivity",
+        device_types=(DEVICE_BRIDGE,),
+        value_fn=lambda data: data.get("is_connected", False),
     ),
 )
 

--- a/custom_components/bhyve/coordinator.py
+++ b/custom_components/bhyve/coordinator.py
@@ -52,6 +52,7 @@ class BHyveDataUpdateCoordinator(DataUpdateCoordinator):
         )
         self.client = client
         self.entry = entry
+        self.gateway_to_bridge: dict[str, str] = {}
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from API (periodic polling)."""

--- a/custom_components/bhyve/strings.json
+++ b/custom_components/bhyve/strings.json
@@ -157,6 +157,9 @@
           "on": "Fault",
           "off": "OK"
         }
+      },
+      "connectivity": {
+        "name": "Connected"
       }
     },
     "sensor": {

--- a/custom_components/bhyve/util.py
+++ b/custom_components/bhyve/util.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.util import dt
 
-from .const import CONF_DEVICES
+from .const import CONF_DEVICES, DEVICE_BRIDGE
 
 
 def orbit_time_to_local_time(timestamp: str | None) -> datetime | None:
@@ -18,9 +18,18 @@ def orbit_time_to_local_time(timestamp: str | None) -> datetime | None:
 
 
 def filter_configured_devices(entry: ConfigEntry, all_devices: list) -> list:
-    """Filter the device list to those that are enabled in options."""
+    """
+    Filter the device list to those that are enabled in options.
+
+    Bridge devices are always included since they are not user-selectable
+    but are needed to register the hub in Home Assistant.
+    """
     configured_devices = entry.options.get(CONF_DEVICES, [])
-    filtered_devices = [d for d in all_devices if str(d["id"]) in configured_devices]
+    filtered_devices = [
+        d
+        for d in all_devices
+        if str(d["id"]) in configured_devices or d.get("type") == DEVICE_BRIDGE
+    ]
 
     # Ensure that all devices have a name
     for device in filtered_devices:

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -197,15 +197,20 @@ class TestAsyncSetupEntry:
         assert len(entities) == EXPECTED_SPRINKLER_ENTITIES
         assert entities[0].entity_description.key == "fault"
 
-    async def test_setup_entry_no_matching_devices(
+    async def test_setup_entry_with_bridge_device(
         self,
         hass: HomeAssistant,
         mock_config_entry: ConfigEntry,
     ) -> None:
-        """Test setting up binary sensors with no matching device types."""
-        # Create coordinator with bridge device (no binary sensors)
+        """Test setting up binary sensors for bridge devices."""
         bridge_device = BHyveDevice(
-            {"id": "test-bridge-123", "type": "bridge", "name": "Bridge"}
+            {
+                "id": "test-bridge-123",
+                "type": "bridge",
+                "name": "Wi-Fi Hub",
+                "mac_address": "44:67:55:22:dc:60",
+                "is_connected": True,
+            }
         )
         coordinator = create_mock_coordinator(
             {
@@ -217,7 +222,6 @@ class TestAsyncSetupEntry:
             }
         )
 
-        # Setup mock data in hass
         hass.data = {
             "bhyve": {
                 "test_entry_id": {
@@ -227,13 +231,45 @@ class TestAsyncSetupEntry:
             }
         }
 
-        # Mock async_add_entities
         async_add_entities = MagicMock()
-
-        # Call setup entry
         await async_setup_entry(hass, mock_config_entry, async_add_entities)
 
-        # Verify no entities were added
+        async_add_entities.assert_called_once()
+        entities = async_add_entities.call_args[0][0]
+        assert len(entities) == 1
+        assert entities[0].entity_description.key == "connectivity"
+
+    async def test_setup_entry_no_matching_devices(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: ConfigEntry,
+    ) -> None:
+        """Test setting up binary sensors with no matching device types."""
+        unknown_device = BHyveDevice(
+            {"id": "test-unknown-123", "type": "unknown_type", "name": "Unknown"}
+        )
+        coordinator = create_mock_coordinator(
+            {
+                "test-unknown-123": {
+                    "device": unknown_device,
+                    "history": [],
+                    "landscapes": {},
+                }
+            }
+        )
+
+        hass.data = {
+            "bhyve": {
+                "test_entry_id": {
+                    "coordinator": coordinator,
+                    "devices": [unknown_device],
+                }
+            }
+        }
+
+        async_add_entities = MagicMock()
+        await async_setup_entry(hass, mock_config_entry, async_add_entities)
+
         async_add_entities.assert_called_once()
         entities = async_add_entities.call_args[0][0]
         assert len(entities) == 0
@@ -735,3 +771,210 @@ class TestBHyveFaultSensor:
         ] = []
 
         assert sensor.is_on is False
+
+
+class TestBHyveBridgeConnectivitySensor:
+    """Test BHyve bridge connectivity binary sensor."""
+
+    @pytest.fixture
+    def mock_bridge_device(self) -> BHyveDevice:
+        """Mock BHyve bridge device."""
+        return BHyveDevice(
+            {
+                "id": "test-bridge-123",
+                "name": "Wi-Fi Hub",
+                "type": "bridge",
+                "mac_address": "44:67:55:22:dc:60",
+                "hardware_version": "BH1G2-0002",
+                "firmware_version": "0056",
+                "is_connected": True,
+                "device_gateway_topic": "devices-1",
+                "status": {
+                    "run_mode": "auto",
+                    "watering_status": None,
+                },
+            }
+        )
+
+    def _create_connectivity_sensor(
+        self, device: BHyveDevice, coordinator: MagicMock
+    ) -> BHyveBinarySensor:
+        """Create a connectivity binary sensor for testing."""
+        description = BINARY_SENSOR_TYPES[3]
+        return BHyveBinarySensor(
+            coordinator=coordinator, device=device, description=description
+        )
+
+    async def test_connectivity_sensor_initialization(
+        self, mock_bridge_device: BHyveDevice
+    ) -> None:
+        """Test connectivity sensor entity initialization."""
+        coordinator = create_mock_coordinator(
+            {
+                "test-bridge-123": {
+                    "device": mock_bridge_device,
+                    "history": [],
+                    "landscapes": {},
+                }
+            }
+        )
+        sensor = self._create_connectivity_sensor(mock_bridge_device, coordinator)
+
+        assert sensor.device_class == BinarySensorDeviceClass.CONNECTIVITY
+        assert sensor.unique_id == "44:67:55:22:dc:60:test-bridge-123:connectivity"
+        assert sensor.name == "Connected"
+
+    async def test_connectivity_sensor_connected(
+        self, mock_bridge_device: BHyveDevice
+    ) -> None:
+        """Test connectivity sensor when bridge is connected."""
+        coordinator = create_mock_coordinator(
+            {
+                "test-bridge-123": {
+                    "device": mock_bridge_device,
+                    "history": [],
+                    "landscapes": {},
+                }
+            }
+        )
+        sensor = self._create_connectivity_sensor(mock_bridge_device, coordinator)
+
+        assert sensor.is_on is True
+
+    async def test_connectivity_sensor_disconnected(self) -> None:
+        """Test connectivity sensor when bridge is disconnected."""
+        device = BHyveDevice(
+            {
+                "id": "test-bridge-456",
+                "name": "Wi-Fi Hub",
+                "type": "bridge",
+                "mac_address": "44:67:55:22:dc:61",
+                "is_connected": False,
+            }
+        )
+        coordinator = create_mock_coordinator(
+            {
+                "test-bridge-456": {
+                    "device": device,
+                    "history": [],
+                    "landscapes": {},
+                }
+            }
+        )
+        sensor = self._create_connectivity_sensor(device, coordinator)
+
+        assert sensor.is_on is False
+
+    async def test_connectivity_sensor_websocket_update(
+        self, mock_bridge_device: BHyveDevice
+    ) -> None:
+        """Test connectivity sensor updates when coordinator data changes."""
+        coordinator = create_mock_coordinator(
+            {
+                "test-bridge-123": {
+                    "device": mock_bridge_device,
+                    "history": [],
+                    "landscapes": {},
+                }
+            }
+        )
+        sensor = self._create_connectivity_sensor(mock_bridge_device, coordinator)
+
+        assert sensor.is_on is True
+
+        # Simulate bridge going offline
+        coordinator.data["devices"]["test-bridge-123"]["device"]["is_connected"] = False
+
+        assert sensor.is_on is False
+
+
+class TestBridgeViaDevice:
+    """Test that child devices reference their bridge via via_device."""
+
+    async def test_child_device_has_via_device(self) -> None:
+        """Test that a flood sensor references its bridge."""
+        flood_device = BHyveDevice(
+            {
+                "id": "test-flood-123",
+                "name": "Basement Flood",
+                "type": "flood_sensor",
+                "mac_address": "aa:bb:cc:dd:ee:ff",
+                "is_connected": True,
+                "device_gateway_topic": "devices-1",
+            }
+        )
+        coordinator = create_mock_coordinator(
+            {
+                "test-flood-123": {
+                    "device": flood_device,
+                    "history": [],
+                    "landscapes": {},
+                }
+            }
+        )
+        coordinator.gateway_to_bridge = {"devices-1": "bridge-id-123"}
+
+        description = BINARY_SENSOR_TYPES[0]
+        sensor = BHyveBinarySensor(
+            coordinator=coordinator, device=flood_device, description=description
+        )
+
+        assert sensor.device_info["via_device"] == ("bhyve", "bridge-id-123")
+
+    async def test_bridge_device_has_no_via_device(self) -> None:
+        """Test that a bridge device does not have via_device."""
+        bridge_device = BHyveDevice(
+            {
+                "id": "test-bridge-123",
+                "name": "Wi-Fi Hub",
+                "type": "bridge",
+                "mac_address": "44:67:55:22:dc:60",
+                "is_connected": True,
+                "device_gateway_topic": "devices-1",
+            }
+        )
+        coordinator = create_mock_coordinator(
+            {
+                "test-bridge-123": {
+                    "device": bridge_device,
+                    "history": [],
+                    "landscapes": {},
+                }
+            }
+        )
+        coordinator.gateway_to_bridge = {"devices-1": "test-bridge-123"}
+
+        description = BINARY_SENSOR_TYPES[3]
+        sensor = BHyveBinarySensor(
+            coordinator=coordinator, device=bridge_device, description=description
+        )
+
+        assert "via_device" not in sensor.device_info
+
+    async def test_child_device_without_gateway_has_no_via_device(self) -> None:
+        """Test that a device without gateway_topic has no via_device."""
+        flood_device = BHyveDevice(
+            {
+                "id": "test-flood-123",
+                "name": "Basement Flood",
+                "type": "flood_sensor",
+                "mac_address": "aa:bb:cc:dd:ee:ff",
+                "is_connected": True,
+            }
+        )
+        coordinator = create_mock_coordinator(
+            {
+                "test-flood-123": {
+                    "device": flood_device,
+                    "history": [],
+                    "landscapes": {},
+                }
+            }
+        )
+
+        description = BINARY_SENSOR_TYPES[0]
+        sensor = BHyveBinarySensor(
+            coordinator=coordinator, device=flood_device, description=description
+        )
+
+        assert "via_device" not in sensor.device_info

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -272,6 +272,39 @@ class TestFilterConfiguredDevices:
         assert len(result) == 0
         assert result == []
 
+    def test_filter_configured_devices_always_includes_bridges(self) -> None:
+        """Test that bridge devices are always included regardless of config."""
+        entry = MagicMock(spec=ConfigEntry)
+        entry.options = {CONF_DEVICES: ["device-1"]}
+
+        devices = [
+            {"id": "bridge-1", "name": "Wi-Fi Hub", "type": "bridge"},
+            {"id": "device-1", "name": "Sprinkler", "type": "sprinkler_timer"},
+            {"id": "device-2", "name": "Flood Sensor", "type": "flood_sensor"},
+        ]
+
+        result = filter_configured_devices(entry, devices)
+
+        device_ids = [d["id"] for d in result]
+        assert "bridge-1" in device_ids
+        assert "device-1" in device_ids
+        assert "device-2" not in device_ids
+
+    def test_filter_configured_devices_bridges_included_with_empty_config(self) -> None:
+        """Test that bridges are included even when no devices are configured."""
+        entry = MagicMock(spec=ConfigEntry)
+        entry.options = {CONF_DEVICES: []}
+
+        devices = [
+            {"id": "bridge-1", "name": "Wi-Fi Hub", "type": "bridge"},
+            {"id": "device-1", "name": "Sprinkler", "type": "sprinkler_timer"},
+        ]
+
+        result = filter_configured_devices(entry, devices)
+
+        assert len(result) == 1
+        assert result[0]["id"] == "bridge-1"
+
     def test_filter_configured_devices_adds_default_name(self) -> None:
         """Test that devices without names get default name."""
         entry = MagicMock(spec=ConfigEntry)


### PR DESCRIPTION
## Summary
- Registers bridge (Wi-Fi Hub) devices in Home Assistant with a **connectivity binary sensor** showing online/offline status
- Links child devices (sprinklers, flood sensors) to their bridge via `via_device`, creating a parent-child device hierarchy in the HA UI
- Exposes **MAC address** on all device types via `CONNECTION_NETWORK_MAC` in `DeviceInfo`
- Bridge devices are **always included** regardless of user device selection in config flow — they are not shown in the device picker since they are infrastructure, not controllable devices

## Changes
- `binary_sensor.py`: Added connectivity binary sensor for bridge devices
- `__init__.py`: Added `via_device` linking, `CONNECTION_NETWORK_MAC` connections, gateway-to-bridge mapping
- `coordinator.py`: Added `gateway_to_bridge` attribute
- `util.py`: `filter_configured_devices` always includes bridge devices
- `strings.json`: Added connectivity sensor translation
- Tests for connectivity sensor, via_device linking, and bridge auto-inclusion

Fixes #338 