### PR TITLE
Add device mode select entity for sprinkler timers

### DIFF
--- a/custom_components/bhyve/__init__.py
+++ b/custom_components/bhyve/__init__.py
@@ -41,6 +41,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
+    Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.VALVE,

--- a/custom_components/bhyve/select.py
+++ b/custom_components/bhyve/select.py
@@ -1,0 +1,97 @@
+"""Support for Orbit BHyve select entities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.const import EntityCategory
+
+from . import BHyveCoordinatorEntity
+from .const import DEVICE_SPRINKLER, DOMAIN
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from .coordinator import BHyveDataUpdateCoordinator
+    from .pybhyve.typings import BHyveDevice
+
+
+@dataclass(frozen=True, kw_only=True)
+class BHyveSelectEntityDescription(SelectEntityDescription):
+    """Describes BHyve select entity."""
+
+    unique_id_suffix: str
+    name: str = ""
+    device_types: tuple[str, ...] = ()
+
+
+SELECT_TYPES: tuple[BHyveSelectEntityDescription, ...] = (
+    BHyveSelectEntityDescription(
+        key="device_mode",
+        translation_key="device_mode",
+        name="Device mode",
+        icon="mdi:auto-mode",
+        unique_id_suffix="device_mode",
+        entity_category=EntityCategory.CONFIG,
+        device_types=(DEVICE_SPRINKLER,),
+        options=["auto", "off"],
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the BHyve select platform from a config entry."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    devices = hass.data[DOMAIN][entry.entry_id]["devices"]
+
+    entities = [
+        BHyveSelectEntity(coordinator, device, description)
+        for device in devices
+        for description in SELECT_TYPES
+        if device.get("type") in description.device_types
+    ]
+
+    async_add_entities(entities)
+
+
+class BHyveSelectEntity(BHyveCoordinatorEntity, SelectEntity):
+    """Define a BHyve select entity."""
+
+    entity_description: BHyveSelectEntityDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: BHyveDataUpdateCoordinator,
+        device: BHyveDevice,
+        description: BHyveSelectEntityDescription,
+    ) -> None:
+        """Initialize the select entity."""
+        self.entity_description = description
+        self._attr_name = description.name
+        super().__init__(coordinator, device)
+        self._attr_unique_id = (
+            f"{self._mac_address}:{self._device_id}:{description.unique_id_suffix}"
+        )
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current selected option."""
+        status = self.device_data.get("status", {})
+        return status.get("mode", status.get("run_mode"))
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        await self.coordinator.client.send_message(
+            {
+                "event": "change_mode",
+                "device_id": self._device_id,
+                "mode": option,
+            }
+        )

--- a/custom_components/bhyve/strings.json
+++ b/custom_components/bhyve/strings.json
@@ -136,6 +136,15 @@
     }
   },
   "entity": {
+    "select": {
+      "device_mode": {
+        "name": "Device mode",
+        "state": {
+          "auto": "Auto",
+          "off": "Off"
+        }
+      }
+    },
     "binary_sensor": {
       "flood": {
         "name": "Flood sensor",

--- a/custom_components/bhyve/translations/en.json
+++ b/custom_components/bhyve/translations/en.json
@@ -136,6 +136,15 @@
     }
   },
   "entity": {
+    "select": {
+      "device_mode": {
+        "name": "Device mode",
+        "state": {
+          "auto": "Auto",
+          "off": "Off"
+        }
+      }
+    },
     "binary_sensor": {
       "flood": {
         "name": "Flood sensor",

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,0 +1,169 @@
+"""Test BHyve select entities."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.helpers.entity import EntityCategory
+
+from custom_components.bhyve.coordinator import BHyveDataUpdateCoordinator
+from custom_components.bhyve.pybhyve.typings import BHyveDevice
+from custom_components.bhyve.select import SELECT_TYPES, BHyveSelectEntity
+
+
+def create_mock_coordinator(devices: dict, programs: dict | None = None) -> MagicMock:
+    """Create a mock coordinator with the given devices."""
+    coordinator = MagicMock(spec=BHyveDataUpdateCoordinator)
+    coordinator.data = {
+        "devices": devices,
+        "programs": programs or {},
+    }
+    coordinator.last_update_success = True
+    coordinator.async_set_updated_data = MagicMock()
+    coordinator.client = MagicMock()
+    coordinator.client.send_message = AsyncMock()
+    return coordinator
+
+
+async def test_select_initialization(
+    mock_sprinkler_device: BHyveDevice,
+) -> None:
+    """Test select entity initialization."""
+    coordinator = create_mock_coordinator(
+        {
+            "test-device-123": {
+                "device": mock_sprinkler_device,
+                "history": [],
+                "landscapes": {},
+            }
+        }
+    )
+
+    description = SELECT_TYPES[0]
+    entity = BHyveSelectEntity(coordinator, mock_sprinkler_device, description)
+
+    assert entity._attr_name == "Device mode"
+    assert entity.unique_id == (
+        f"{mock_sprinkler_device['mac_address']}:"
+        f"{mock_sprinkler_device['id']}:device_mode"
+    )
+    assert entity.entity_description.entity_category == EntityCategory.CONFIG
+    assert entity.entity_description.options == ["auto", "off"]
+
+
+async def test_select_current_option(
+    mock_sprinkler_device: BHyveDevice,
+) -> None:
+    """Test current_option returns run_mode from device status."""
+    coordinator = create_mock_coordinator(
+        {
+            "test-device-123": {
+                "device": mock_sprinkler_device,
+                "history": [],
+                "landscapes": {},
+            }
+        }
+    )
+
+    entity = BHyveSelectEntity(coordinator, mock_sprinkler_device, SELECT_TYPES[0])
+
+    assert entity.current_option == "auto"
+
+
+async def test_select_option_off(
+    mock_sprinkler_device: BHyveDevice,
+) -> None:
+    """Test selecting 'off' sends correct websocket message."""
+    coordinator = create_mock_coordinator(
+        {
+            "test-device-123": {
+                "device": mock_sprinkler_device,
+                "history": [],
+                "landscapes": {},
+            }
+        }
+    )
+
+    entity = BHyveSelectEntity(coordinator, mock_sprinkler_device, SELECT_TYPES[0])
+
+    await entity.async_select_option("off")
+
+    coordinator.client.send_message.assert_called_once_with(
+        {
+            "event": "change_mode",
+            "device_id": "test-device-123",
+            "mode": "off",
+        }
+    )
+
+
+async def test_select_option_auto(
+    mock_sprinkler_device: BHyveDevice,
+) -> None:
+    """Test selecting 'auto' sends correct websocket message."""
+    coordinator = create_mock_coordinator(
+        {
+            "test-device-123": {
+                "device": mock_sprinkler_device,
+                "history": [],
+                "landscapes": {},
+            }
+        }
+    )
+
+    entity = BHyveSelectEntity(coordinator, mock_sprinkler_device, SELECT_TYPES[0])
+
+    await entity.async_select_option("auto")
+
+    coordinator.client.send_message.assert_called_once_with(
+        {
+            "event": "change_mode",
+            "device_id": "test-device-123",
+            "mode": "auto",
+        }
+    )
+
+
+async def test_select_current_option_from_websocket_event(
+    mock_sprinkler_device: BHyveDevice,
+) -> None:
+    """Test current_option reads 'mode' field set by websocket events."""
+    device_data = dict(mock_sprinkler_device)
+    device_data["status"] = {"run_mode": "auto", "mode": "off"}
+    device = BHyveDevice(device_data)
+
+    coordinator = create_mock_coordinator(
+        {
+            "test-device-123": {
+                "device": device,
+                "history": [],
+                "landscapes": {},
+            }
+        }
+    )
+
+    entity = BHyveSelectEntity(coordinator, device, SELECT_TYPES[0])
+
+    # 'mode' (from websocket event) takes precedence over 'run_mode'
+    assert entity.current_option == "off"
+
+
+async def test_select_current_option_missing_status(
+    mock_sprinkler_device: BHyveDevice,
+) -> None:
+    """Test current_option returns None when status is missing."""
+    device_data = dict(mock_sprinkler_device)
+    del device_data["status"]
+    device_no_status = BHyveDevice(device_data)
+
+    coordinator = create_mock_coordinator(
+        {
+            "test-device-123": {
+                "device": device_no_status,
+                "history": [],
+                "landscapes": {},
+            }
+        }
+    )
+
+    entity = BHyveSelectEntity(coordinator, device_no_status, SELECT_TYPES[0])
+
+    assert entity.current_option is None


### PR DESCRIPTION
## Summary
- Adds a new `select` entity for sprinkler_timer devices with "Auto" and "Off" options

Closes #263