### PR TITLE
Fix authentication error handling and trigger reauth flow

### DIFF
--- a/custom_components/bhyve/__init__.py
+++ b/custom_components/bhyve/__init__.py
@@ -74,9 +74,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         if await client.login() is False:
+            _LOGGER.warning("Invalid credentials for %s", entry.data[CONF_USERNAME])
             msg = "Invalid credentials"
             raise ConfigEntryAuthFailed(msg)
     except AuthenticationError as err:
+        _LOGGER.warning("Authentication failed for %s", entry.data[CONF_USERNAME])
         raise ConfigEntryAuthFailed(err) from err
     except BHyveError as err:
         raise ConfigEntryNotReady(err) from err
@@ -177,6 +179,12 @@ async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
+    data = hass.data[DOMAIN].get(entry.entry_id)
+    if data:
+        client = data.get("client")
+        if client:
+            await client.stop()
+
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
 

--- a/custom_components/bhyve/coordinator.py
+++ b/custom_components/bhyve/coordinator.py
@@ -7,6 +7,7 @@ import logging
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -122,8 +123,8 @@ class BHyveDataUpdateCoordinator(DataUpdateCoordinator):
             return data  # noqa: TRY300
 
         except AuthenticationError as err:
-            msg = "Authentication failed"
-            raise UpdateFailed(msg) from err
+            _LOGGER.warning("Authentication failed, triggering reauth: %s", err)
+            raise ConfigEntryAuthFailed from err
         except BHyveError as err:
             msg = f"Error communicating with API: {err}"
             raise UpdateFailed(msg) from err

--- a/custom_components/bhyve/pybhyve/client.py
+++ b/custom_components/bhyve/pybhyve/client.py
@@ -82,6 +82,12 @@ class BHyveClient:
             try:
                 resp.raise_for_status()
                 return await resp.json(content_type=None)
+            except ClientResponseError as err:
+                if err.status in (401, 403):
+                    _LOGGER.warning("Authentication error from %s: %s", url, err.status)
+                    raise AuthenticationError from err
+                msg = f"Error requesting data from {url}: {err}"
+                raise RequestError(msg) from err
             except Exception as err:
                 msg = f"Error requesting data from {url}: {err}"
                 raise RequestError(msg) from err
@@ -168,7 +174,7 @@ class BHyveClient:
                 self._token = response["orbit_session_token"]
 
             except ClientResponseError as response_err:
-                if response_err.status == 400:  # noqa: PLR2004
+                if response_err.status in (401, 403):
                     raise AuthenticationError from response_err
                 raise RequestError from response_err
             except Exception as err:


### PR DESCRIPTION
## Summary
- **client.py**: Detect 401/403 responses in both `login()` and `_request()` as `AuthenticationError` (previously `login()` only checked for 400, and `_request()` wrapped all errors as generic `RequestError`)
- **coordinator.py**: Raise `ConfigEntryAuthFailed` instead of `UpdateFailed` on auth errors, triggering HA's reauth flow
- **__init__.py**: Stop the websocket client in `async_unload_entry` so stale connections don't retry forever after reauth, and add warning logs for auth failures during setup

Closes #159