### PR TITLE
Fix options flow crash when a device is removed from B-hyve account

### DIFF
--- a/custom_components/bhyve/config_flow.py
+++ b/custom_components/bhyve/config_flow.py
@@ -222,13 +222,18 @@ class BhyveOptionsFlowHandler(OptionsFlowWithReload):
             if d.get("type") != DEVICE_BRIDGE
         }
 
+        # Filter saved defaults to only include devices that still exist,
+        # in case a device was removed from the B-hyve account.
+        saved_devices = self.config_entry.options.get(CONF_DEVICES, [])
+        valid_defaults = [d for d in saved_devices if d in device_options]
+
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
                 {
                     vol.Required(
                         CONF_DEVICES,
-                        default=self.config_entry.options.get(CONF_DEVICES),
+                        default=valid_defaults,
                     ): cv.multi_select(device_options),
                 }
             ),


### PR DESCRIPTION
## Summary
- Filters saved device defaults in the options flow to only include devices that still exist in the B-hyve API response
- Previously, if a device was removed from the B-hyve account, its stale ID remained in the config entry options and caused a validation error: `"is not a valid option for dictionary value @ data['devices']"`

Closes #203
