### PR TITLE
Handle TimeoutError gracefully to prevent blocking HA startup

### DIFF
--- a/custom_components/bhyve/__init__.py
+++ b/custom_components/bhyve/__init__.py
@@ -80,7 +80,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except AuthenticationError as err:
         _LOGGER.warning("Authentication failed for %s", entry.data[CONF_USERNAME])
         raise ConfigEntryAuthFailed(err) from err
-    except BHyveError as err:
+    except (BHyveError, TimeoutError) as err:
         raise ConfigEntryNotReady(err) from err
 
     # Create coordinator
@@ -103,8 +103,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     client.listen(hass.loop, async_update_callback)
 
     # Filter the device list to those that are enabled in options
-    all_devices = await client.devices
-    programs = await client.timer_programs
+    try:
+        all_devices = await client.devices
+        programs = await client.timer_programs
+    except (BHyveError, TimeoutError) as err:
+        raise ConfigEntryNotReady(err) from err
     devices = filter_configured_devices(entry, all_devices)
 
     # Build a mapping from device_gateway_topic to bridge device ID
@@ -171,7 +174,7 @@ async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
             if removed_device_ids:
                 # Remove devices from Home Assistant
                 await remove_devices_from_registry(hass, removed_device_ids)
-        except (BHyveError, KeyError) as err:
+        except (BHyveError, KeyError, TimeoutError) as err:
             _LOGGER.warning("Error checking for removed devices: %s", err)
 
     await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/bhyve/config_flow.py
+++ b/custom_components/bhyve/config_flow.py
@@ -211,7 +211,7 @@ class BhyveOptionsFlowHandler(OptionsFlowWithReload):
             devices = await client.devices
         except AuthenticationError:
             return self.async_abort(reason="invalid_auth")
-        except BHyveError:
+        except (BHyveError, TimeoutError):
             return self.async_abort(reason="cannot_connect")
 
         _LOGGER.debug("Devices: %s", json.dumps(devices))

--- a/custom_components/bhyve/coordinator.py
+++ b/custom_components/bhyve/coordinator.py
@@ -125,7 +125,7 @@ class BHyveDataUpdateCoordinator(DataUpdateCoordinator):
         except AuthenticationError as err:
             _LOGGER.warning("Authentication failed, triggering reauth: %s", err)
             raise ConfigEntryAuthFailed from err
-        except BHyveError as err:
+        except (BHyveError, TimeoutError) as err:
             msg = f"Error communicating with API: {err}"
             raise UpdateFailed(msg) from err
 
@@ -133,7 +133,7 @@ class BHyveDataUpdateCoordinator(DataUpdateCoordinator):
         """Fetch watering history for a device."""
         try:
             history = await self.client.get_device_history(device_id)
-        except BHyveError as err:
+        except (BHyveError, TimeoutError) as err:
             _LOGGER.debug("Could not fetch history for device %s: %s", device_id, err)
             return []
         else:
@@ -161,7 +161,7 @@ class BHyveDataUpdateCoordinator(DataUpdateCoordinator):
             try:
                 landscape = await self.client.get_landscape(device_id, zone_id)
                 return str(zone_id), landscape if landscape else None
-            except BHyveError as err:
+            except (BHyveError, TimeoutError) as err:
                 _LOGGER.debug(
                     "Could not fetch landscape for device %s zone %s: %s",
                     device_id,

--- a/custom_components/bhyve/pybhyve/client.py
+++ b/custom_components/bhyve/pybhyve/client.py
@@ -76,21 +76,27 @@ class BHyveClient:
             "Chrome/72.0.3626.81 Safari/537.36"
         )
 
-        async with self._session.request(
-            method, url, params=params, headers=headers, json=json
-        ) as resp:
-            try:
-                resp.raise_for_status()
-                return await resp.json(content_type=None)
-            except ClientResponseError as err:
-                if err.status in (401, 403):
-                    _LOGGER.warning("Authentication error from %s: %s", url, err.status)
-                    raise AuthenticationError from err
-                msg = f"Error requesting data from {url}: {err}"
-                raise RequestError(msg) from err
-            except Exception as err:
-                msg = f"Error requesting data from {url}: {err}"
-                raise RequestError(msg) from err
+        try:
+            async with self._session.request(
+                method, url, params=params, headers=headers, json=json
+            ) as resp:
+                try:
+                    resp.raise_for_status()
+                    return await resp.json(content_type=None)
+                except ClientResponseError as err:
+                    if err.status in (401, 403):
+                        _LOGGER.warning(
+                            "Authentication error from %s: %s", url, err.status
+                        )
+                        raise AuthenticationError from err
+                    msg = f"Error requesting data from {url}: {err}"
+                    raise RequestError(msg) from err
+                except Exception as err:
+                    msg = f"Error requesting data from {url}: {err}"
+                    raise RequestError(msg) from err
+        except TimeoutError as err:
+            msg = f"Timeout requesting data from {url}"
+            raise RequestError(msg) from err
 
     async def _refresh_devices(self, *, force_update: bool = False) -> None:
         now = time.time()
@@ -166,20 +172,24 @@ class BHyveClient:
         url: str = f"{API_HOST}{LOGIN_PATH}"
         json = {"session": {"email": self._username, "password": self._password}}
 
-        async with self._session.request("post", url, json=json) as resp:
-            try:
-                resp.raise_for_status()
-                response = await resp.json(content_type=None)
-                _LOGGER.debug("Logged in")
-                self._token = response["orbit_session_token"]
+        try:
+            async with self._session.request("post", url, json=json) as resp:
+                try:
+                    resp.raise_for_status()
+                    response = await resp.json(content_type=None)
+                    _LOGGER.debug("Logged in")
+                    self._token = response["orbit_session_token"]
 
-            except ClientResponseError as response_err:
-                if response_err.status in (401, 403):
-                    raise AuthenticationError from response_err
-                raise RequestError from response_err
-            except Exception as err:
-                msg = f"Error requesting data from {url}: {err}"
-                raise RequestError(msg) from err
+                except ClientResponseError as response_err:
+                    if response_err.status in (401, 403):
+                        raise AuthenticationError from response_err
+                    raise RequestError from response_err
+                except Exception as err:
+                    msg = f"Error requesting data from {url}: {err}"
+                    raise RequestError(msg) from err
+        except TimeoutError as err:
+            msg = f"Timeout requesting data from {url}"
+            raise RequestError(msg) from err
 
         return self._token is not None
 


### PR DESCRIPTION
## Summary

Fixes #370

- Wraps `TimeoutError` from aiohttp requests in `RequestError` at the API client level (`client.py`), converting it into the `BHyveError` hierarchy so all existing error handlers catch it automatically
- Adds defense-in-depth `TimeoutError` handling at the integration setup (`__init__.py`), coordinator (`coordinator.py`), and options flow (`config_flow.py`) layers
- Transient API timeouts during startup now raise `ConfigEntryNotReady`, which tells HA to retry with exponential backoff instead of blocking startup
- Transient API timeouts during polling raise `UpdateFailed`, which preserves the last known cached data and retries at the next coordinator interval — entities stay available with slightly stale data

## Test plan

- [x] Existing tests pass (133 passed, 5 skipped)
- [x] Linting passes
- [ ] Verify HA starts normally when B-hyve API is temporarily unreachable
- [ ] Verify entities recover and update once the API becomes available again