### PR TITLE
Fix bhyve service calls on valve entities

### DIFF
--- a/custom_components/bhyve/__init__.py
+++ b/custom_components/bhyve/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.exceptions import (
     ConfigEntryNotReady,
     HomeAssistantError,
 )
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
@@ -46,6 +47,8 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
     Platform.VALVE,
 ]
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/custom_components/bhyve/pybhyve/client.py
+++ b/custom_components/bhyve/pybhyve/client.py
@@ -276,3 +276,23 @@ class BHyveClient:
         """Send a message via the websocket."""
         if self._websocket is not None:
             await self._websocket.send(payload)
+
+    async def set_rain_delay(self, device_id: str, hours: int) -> None:
+        """Set rain delay hours for a device. Use hours=0 to disable."""
+        payload = {
+            "event": "rain_delay",
+            "device_id": device_id,
+            "delay": hours,
+        }
+        _LOGGER.info("Setting rain delay: %s", payload)
+        await self.send_message(payload)
+
+    async def set_manual_preset_runtime(self, device_id: str, minutes: int) -> None:
+        """Set the default watering runtime for a device."""
+        payload = {
+            "event": "set_manual_preset_runtime",
+            "device_id": device_id,
+            "seconds": minutes * 60,
+        }
+        _LOGGER.info("Setting manual preset runtime: %s", payload)
+        await self.send_message(payload)

--- a/custom_components/bhyve/services.yaml
+++ b/custom_components/bhyve/services.yaml
@@ -69,7 +69,7 @@ update_program:
       description: List of watering start times in HH:MM format
       example: '["06:00", "18:00"]'
     frequency:
-      description: Frequency configuration. `type` is required (known values: days, interval)
+      description: "Frequency configuration. `type` is required (known values: days, interval)"
       example: '{"type": "days", "days": [1, 3, 5], "interval": 1, "interval_hours": 0}'
     budget:
       description: Watering budget as a percentage (0-200). Scales run times up or down

--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -505,32 +505,8 @@ class BHyveRainDelaySwitch(BHyveCoordinatorEntity, SwitchEntity):
 
     async def async_turn_on(self, **_kwargs: Any) -> None:
         """Turn the switch on."""
-        await self._enable_rain_delay()
+        await self.coordinator.client.set_rain_delay(self._device_id, 24)
 
     async def async_turn_off(self, **_kwargs: Any) -> None:
         """Turn the switch off."""
-        await self._disable_rain_delay()
-
-    async def _enable_rain_delay(self, hours: int = 24) -> None:
-        """Enable rain delay."""
-        await self._set_rain_delay(hours)
-
-    async def _disable_rain_delay(self) -> None:
-        """Disable rain delay."""
-        await self._set_rain_delay(0)
-
-    async def _set_rain_delay(self, hours: int) -> None:
-        """Set rain delay hours."""
-        try:
-            payload = {
-                "event": "rain_delay",
-                "device_id": self._device_id,
-                "delay": hours,
-            }
-            _LOGGER.info("Setting rain delay: %s", payload)
-            await self.coordinator.client.send_message(payload)
-            # Coordinator updates via WebSocket event
-
-        except BHyveError as err:
-            _LOGGER.warning("Failed to send to BHyve websocket message %s", err)
-            raise
+        await self.coordinator.client.set_rain_delay(self._device_id, 0)

--- a/custom_components/bhyve/valve.py
+++ b/custom_components/bhyve/valve.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
+from homeassistant.components.switch.const import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.valve import (
     ValveDeviceClass,
     ValveEntity,
@@ -207,20 +208,29 @@ async def async_setup_entry(
         params = {
             key: value for key, value in service.data.items() if key != ATTR_ENTITY_ID
         }
-        entity_ids = service.data.get(ATTR_ENTITY_ID)
-        component = hass.data.get(VALVE_DOMAIN)
-        if entity_ids and component is not None:
-            target_vales = [component.get_entity(entity) for entity in entity_ids]
-        else:
-            return
-
+        entity_ids = service.data.get(ATTR_ENTITY_ID) or []
         method_name = method["method"]
         _LOGGER.debug("Service handler: %s %s", method_name, params)
 
-        for entity in target_vales:
+        valve_component = hass.data.get(VALVE_DOMAIN)
+        switch_component = hass.data.get(SWITCH_DOMAIN)
+
+        for entity_id in entity_ids:
+            entity = None
+            if valve_component is not None:
+                entity = valve_component.get_entity(entity_id)
+            if entity is None and switch_component is not None:
+                entity = switch_component.get_entity(entity_id)
+            if entity is None:
+                _LOGGER.error("Entity not found: %s", entity_id)
+                continue
             if not hasattr(entity, method_name):
-                _LOGGER.error("Service not implemented: %s", method_name)
-                return
+                _LOGGER.error(
+                    "Service %s is not supported by entity %s",
+                    method_name,
+                    entity_id,
+                )
+                continue
             await getattr(entity, method_name)(**params)
 
     for service, details in SERVICE_TO_METHOD.items():
@@ -524,6 +534,20 @@ class BHyveZoneValve(BHyveCoordinatorEntity, ValveEntity):
         station_payload = []
         self._attr_is_closed = True
         await self._send_station_message(station_payload)
+
+    async def enable_rain_delay(self, hours: int = 24) -> None:
+        """Enable rain delay for the device."""
+        await self.coordinator.client.set_rain_delay(self._device_id, hours)
+
+    async def disable_rain_delay(self) -> None:
+        """Disable rain delay for the device."""
+        await self.coordinator.client.set_rain_delay(self._device_id, 0)
+
+    async def set_manual_preset_runtime(self, minutes: int) -> None:
+        """Set the default watering runtime for the device."""
+        await self.coordinator.client.set_manual_preset_runtime(
+            self._device_id, minutes
+        )
 
     async def async_open_valve(self) -> None:
         """Open the valve."""

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -40,6 +40,8 @@ def create_mock_coordinator(devices: dict, programs: dict) -> MagicMock:
     coordinator.client.send_message = AsyncMock()
     coordinator.client.update_program = AsyncMock()
     coordinator.client.update_device = AsyncMock()
+    coordinator.client.set_rain_delay = AsyncMock()
+    coordinator.client.set_manual_preset_runtime = AsyncMock()
     return coordinator
 
 
@@ -811,12 +813,10 @@ class TestBHyveRainDelaySwitch:
         # Turn on the switch
         await switch.async_turn_on()
 
-        # Verify send_message was called with delay=24
-        mock_coordinator.client.send_message.assert_called_once()
-        payload = mock_coordinator.client.send_message.call_args[0][0]
-        assert payload["event"] == "rain_delay"
-        assert payload["device_id"] == TEST_DEVICE_ID
-        assert payload["delay"] == 24  # Default 24 hours
+        # Verify set_rain_delay was called with the default 24 hours
+        mock_coordinator.client.set_rain_delay.assert_called_once_with(
+            TEST_DEVICE_ID, 24
+        )
 
     async def test_rain_delay_switch_turn_off(
         self,
@@ -846,12 +846,8 @@ class TestBHyveRainDelaySwitch:
         # Turn off the switch
         await switch.async_turn_off()
 
-        # Verify send_message was called with delay=0
-        coordinator.client.send_message.assert_called_once()
-        payload = coordinator.client.send_message.call_args[0][0]
-        assert payload["event"] == "rain_delay"
-        assert payload["device_id"] == TEST_DEVICE_ID
-        assert payload["delay"] == 0
+        # Verify set_rain_delay was called with 0 hours to disable
+        coordinator.client.set_rain_delay.assert_called_once_with(TEST_DEVICE_ID, 0)
 
     async def test_rain_delay_switch_websocket_event(
         self,

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -26,6 +26,8 @@ def create_mock_coordinator(devices: dict, programs: dict | None = None) -> Magi
     coordinator.client.send_message = AsyncMock()
     coordinator.client.get_landscape = AsyncMock()
     coordinator.client.update_landscape = AsyncMock()
+    coordinator.client.set_rain_delay = AsyncMock()
+    coordinator.client.set_manual_preset_runtime = AsyncMock()
     return coordinator
 
 
@@ -352,3 +354,93 @@ async def test_valve_with_landscape_data(
     attrs = valve.extra_state_attributes
     assert attrs.get("landscape_image") == "https://example.com/landscape.jpg"
     assert attrs.get("sprinkler_type") == "spray"
+
+
+async def test_valve_enable_rain_delay(
+    mock_sprinkler_device: BHyveDevice,
+    mock_zone_data: BHyveZone,
+) -> None:
+    """Test enabling rain delay via the valve service method."""
+    coordinator = create_mock_coordinator(
+        {
+            "test-device-123": {
+                "device": mock_sprinkler_device,
+                "history": [],
+                "landscapes": {},
+            }
+        }
+    )
+
+    valve = BHyveZoneValve(
+        coordinator=coordinator,
+        device=mock_sprinkler_device,
+        zone=mock_zone_data,
+        zone_name="Front Yard",
+        device_programs=[],
+    )
+
+    await valve.enable_rain_delay(hours=5)
+
+    coordinator.client.set_rain_delay.assert_called_once_with(
+        mock_sprinkler_device["id"], 5
+    )
+
+
+async def test_valve_disable_rain_delay(
+    mock_sprinkler_device: BHyveDevice,
+    mock_zone_data: BHyveZone,
+) -> None:
+    """Test disabling rain delay via the valve service method."""
+    coordinator = create_mock_coordinator(
+        {
+            "test-device-123": {
+                "device": mock_sprinkler_device,
+                "history": [],
+                "landscapes": {},
+            }
+        }
+    )
+
+    valve = BHyveZoneValve(
+        coordinator=coordinator,
+        device=mock_sprinkler_device,
+        zone=mock_zone_data,
+        zone_name="Front Yard",
+        device_programs=[],
+    )
+
+    await valve.disable_rain_delay()
+
+    coordinator.client.set_rain_delay.assert_called_once_with(
+        mock_sprinkler_device["id"], 0
+    )
+
+
+async def test_valve_set_manual_preset_runtime(
+    mock_sprinkler_device: BHyveDevice,
+    mock_zone_data: BHyveZone,
+) -> None:
+    """Test setting manual preset runtime via the valve service method."""
+    coordinator = create_mock_coordinator(
+        {
+            "test-device-123": {
+                "device": mock_sprinkler_device,
+                "history": [],
+                "landscapes": {},
+            }
+        }
+    )
+
+    valve = BHyveZoneValve(
+        coordinator=coordinator,
+        device=mock_sprinkler_device,
+        zone=mock_zone_data,
+        zone_name="Front Yard",
+        device_programs=[],
+    )
+
+    await valve.set_manual_preset_runtime(minutes=8)
+
+    coordinator.client.set_manual_preset_runtime.assert_called_once_with(
+        mock_sprinkler_device["id"], 8
+    )


### PR DESCRIPTION
## Summary
- `bhyve.enable_rain_delay`, `disable_rain_delay`, `set_manual_preset_runtime` and `start_program` were broken after the switch→valve conversion — the services were registered but the corresponding methods never got ported onto `BHyveZoneValve`, and the handler only searched the valve domain for target entities.
- Moves websocket payload construction for rain delay and manual preset runtime onto `BHyveClient`, gives `BHyveZoneValve` thin service wrappers that delegate to the client, and routes the service handler through both the valve and switch domains so `start_program` finds program switches.
- `BHyveRainDelaySwitch.async_turn_on/off` now call the same client methods, removing the duplicated `_set_rain_delay` implementation.
