### PR TITLE
Remove deprecated YAML configuration support

### DIFF
--- a/custom_components/bhyve/__init__.py
+++ b/custom_components/bhyve/__init__.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_PASSWORD,
     CONF_USERNAME,
@@ -16,11 +16,9 @@ from homeassistant.exceptions import (
     ConfigEntryNotReady,
     HomeAssistantError,
 )
-from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
-from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.bhyve.pybhyve.typings import BHyveDevice
@@ -47,24 +45,6 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
     Platform.VALVE,
 ]
-
-CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the BHyve component from YAML."""
-    if DOMAIN not in config:
-        return True
-
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=config[DOMAIN],
-        )
-    )
-
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/bhyve/config_flow.py
+++ b/custom_components/bhyve/config_flow.py
@@ -149,36 +149,6 @@ class BHyveConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_step_import(
-        self, config: dict[str, Any] | None
-    ) -> ConfigFlowResult:
-        """Handle import of BHyve config from YAML."""
-        if config is None:
-            return self.async_abort(reason="cannot_connect")
-        username = config[CONF_USERNAME]
-        password = config[CONF_PASSWORD]
-
-        credentials = {
-            CONF_USERNAME: username,
-            CONF_PASSWORD: password,
-        }
-
-        if not (_errors := await self.async_auth(credentials)):
-            await self.async_set_unique_id(credentials[CONF_USERNAME].lower())
-            self._abort_if_unique_id_configured()
-
-            self.data = credentials
-            self.devices = await self.client.devices  # type: ignore[union-attr]
-            self.programs = await self.client.timer_programs  # type: ignore[union-attr]
-
-            devices = [
-                str(d["id"]) for d in (self.devices or []) if d["type"] != DEVICE_BRIDGE
-            ]
-
-            return await self.async_step_device(user_input={CONF_DEVICES: devices})
-
-        return self.async_abort(reason="cannot_connect")
-
     @staticmethod
     @callback
     def async_get_options_flow(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -290,56 +290,6 @@ class TestConfigFlow:
             assert result["step_id"] == "reauth"
             assert result["errors"] == {"base": "invalid_auth"}
 
-    async def test_import_flow_success(
-        self, hass: HomeAssistant, mock_bhyve_client: MagicMock
-    ) -> None:
-        """Test successful import flow."""
-        config = {
-            CONF_USERNAME: TEST_USERNAME,
-            CONF_PASSWORD: TEST_PASSWORD,
-        }
-
-        with (
-            patch(
-                "custom_components.bhyve.config_flow.BHyveClient",
-                return_value=mock_bhyve_client,
-            ),
-            patch.object(ConfigFlow, "async_set_unique_id"),
-            patch.object(ConfigFlow, "_abort_if_unique_id_configured"),
-        ):
-            flow = ConfigFlow()
-            flow.hass = hass
-
-            result = await flow.async_step_import(config)
-
-            assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-            assert result["title"] == TEST_USERNAME
-            assert result["data"] == config
-            # Should auto-select all non-bridge devices
-            assert result["options"] == {CONF_DEVICES: [TEST_DEVICE_ID, "device-789"]}
-
-    async def test_import_flow_auth_error(self, hass: HomeAssistant) -> None:
-        """Test import flow with auth error."""
-        mock_client = MagicMock()
-        mock_client.login = AsyncMock(side_effect=AuthenticationError("Invalid"))
-
-        config = {
-            CONF_USERNAME: TEST_USERNAME,
-            CONF_PASSWORD: "wrong_password",
-        }
-
-        with patch(
-            "custom_components.bhyve.config_flow.BHyveClient",
-            return_value=mock_client,
-        ):
-            flow = ConfigFlow()
-            flow.hass = hass
-
-            result = await flow.async_step_import(config)
-
-            assert result["type"] == data_entry_flow.FlowResultType.ABORT
-            assert result["reason"] == "cannot_connect"
-
 
 @pytest.mark.skip(
     reason="OptionsFlow tests disabled due to Home Assistant framework constraints"


### PR DESCRIPTION
## Summary
- Drop `async_setup`, `CONFIG_SCHEMA`, and the `SOURCE_IMPORT` path from `custom_components/bhyve/__init__.py` so the integration only loads via a config entry.
- Remove `async_step_import` from the config flow along with the two import-flow tests in `tests/test_config_flow.py`.

YAML setup has been marked deprecated for a while (CLAUDE.md already documents UI-only setup). Anyone still booting from YAML will have an existing config entry from a prior import, so removal is effectively a no-op at runtime.

## Test plan
- [x] `./scripts/lint`
- [x] `pytest tests/test_config_flow.py`