### PR TITLE
Fix current_runtime attribute on valve entities

### DIFF
--- a/custom_components/bhyve/coordinator.py
+++ b/custom_components/bhyve/coordinator.py
@@ -194,6 +194,31 @@ class BHyveDataUpdateCoordinator(DataUpdateCoordinator):
 
         return landscapes
 
+    @staticmethod
+    def _apply_watering_in_progress(
+        device_data: dict[str, Any], event_data: dict[str, Any]
+    ) -> None:
+        """Apply a watering_in_progress_notification event to device state."""
+        status = device_data.setdefault("status", {})
+        current_station = event_data.get("current_station")
+        run_time = event_data.get("run_time")
+        stations = event_data.get("stations") or []
+        # The event provides run_time at the top level without a stations array.
+        # Synthesize one so the shape matches the API response and
+        # current_runtime stays populated for valve entities.
+        if not stations and run_time is not None and current_station is not None:
+            stations = [{"station": current_station, "run_time": run_time}]
+        status["watering_status"] = {
+            "current_station": current_station,
+            "program": event_data.get("program"),
+            "run_time": run_time,
+            "started_watering_station_at": event_data.get(
+                "started_watering_station_at"
+            ),
+            "stations": stations,
+        }
+        status["run_mode"] = event_data.get("mode", "manual")
+
     async def async_handle_device_event(self, event_data: dict[str, Any]) -> None:  # noqa: PLR0912
         """Handle WebSocket device events."""
         if not self.data:
@@ -234,20 +259,7 @@ class BHyveDataUpdateCoordinator(DataUpdateCoordinator):
                 del device_data["status"]["watering_status"]
 
         elif event == EVENT_WATERING_IN_PROGRESS:
-            # Update watering status
-            if "status" not in device_data:
-                device_data["status"] = {}
-            # Store the full watering status from the event
-            device_data["status"]["watering_status"] = {
-                "current_station": event_data.get("current_station"),
-                "program": event_data.get("program"),
-                "run_time": event_data.get("run_time"),
-                "started_watering_station_at": event_data.get(
-                    "started_watering_station_at"
-                ),
-                "stations": event_data.get("stations", []),
-            }
-            device_data["status"]["run_mode"] = event_data.get("mode", "manual")
+            self._apply_watering_in_progress(device_data, event_data)
 
         elif event == EVENT_WATERING_COMPLETE:
             # Clear watering status

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -197,3 +197,38 @@ class TestProgramEventHandling:
         # Verify no changes and no update triggered
         assert "unknown-program-id" not in coordinator.data["programs"]
         mock_update.assert_not_called()
+
+
+class TestDeviceEventHandling:
+    """Test device event handling in coordinator."""
+
+    async def test_handle_watering_in_progress_synthesizes_stations(
+        self, hass: HomeAssistant
+    ) -> None:
+        """
+        Synthesize a stations entry from top-level run_time.
+
+        The `watering_in_progress_notification` WebSocket event provides
+        `run_time` at the top level but does not include a `stations` array.
+        Downstream entities read runtime from `watering_status.stations[0]`,
+        so the coordinator must populate it so `current_runtime` is not lost.
+        """
+        coordinator = create_mock_coordinator(hass)
+
+        event_data = {
+            "event": "watering_in_progress_notification",
+            "device_id": TEST_DEVICE_ID,
+            "program": "e",
+            "current_station": 1,
+            "run_time": 14,
+            "started_watering_station_at": "2020-01-09T20:29:59.000Z",
+        }
+
+        with patch.object(coordinator, "async_set_updated_data"):
+            await coordinator.async_handle_device_event(event_data)
+
+        watering_status = coordinator.data["devices"][TEST_DEVICE_ID]["device"][
+            "status"
+        ]["watering_status"]
+        assert watering_status["current_station"] == 1
+        assert watering_status["stations"] == [{"station": 1, "run_time": 14}]


### PR DESCRIPTION
## Summary
- The `watering_in_progress_notification` WebSocket event delivers `run_time` at the top level and does not include a `stations` array. The coordinator was saving `watering_status.stations` as `[]`, and the valve entity reads `stations[0].run_time` to populate `current_runtime`, so the attribute stayed `null` whenever watering started via a WebSocket event.
- Synthesize a `stations` entry from the event's `current_station` and `run_time` so the stored shape matches the API response and `current_runtime` stays populated on valve entities.

Fixes #394

## Test plan
- [x] New regression test `test_handle_watering_in_progress_synthesizes_stations` in `tests/test_coordinator.py`
- [x] `./scripts/test` — 142 passed
- [x] `./scripts/lint` — all checks passed