### PR TITLE
Remove unused module-level constants

### DIFF
--- a/custom_components/bhyve/const.py
+++ b/custom_components/bhyve/const.py
@@ -7,11 +7,6 @@ LOGGER: Logger = getLogger(__package__)
 DOMAIN = "bhyve"
 MANUFACTURER = "Orbit BHyve"
 
-DEVICES = "devices"
-PROGRAMS = "programs"
-
-DATA_BHYVE = "bhyve_data"
-
 CONF_CLIENT = "client"
 CONF_DEVICES = "devices"
 
@@ -29,9 +24,3 @@ EVENT_RAIN_DELAY = "rain_delay"
 EVENT_SET_MANUAL_PRESET_TIME = "set_manual_preset_runtime"
 EVENT_WATERING_COMPLETE = "watering_complete"
 EVENT_WATERING_IN_PROGRESS = "watering_in_progress_notification"
-
-SIGNAL_UPDATE_DEVICE = "bhyve_update_device_{}"
-SIGNAL_UPDATE_PROGRAM = "bhyve_update_program_{}"
-
-TYPE_BINARY_SENSOR = "binary_sensor"
-TYPE_SENSOR = "sensor"

--- a/custom_components/bhyve/diagnostics.py
+++ b/custom_components/bhyve/diagnostics.py
@@ -14,9 +14,6 @@ if TYPE_CHECKING:
 
     from .pybhyve.client import BHyveClient
 
-CONF_ALTITUDE = "altitude"
-CONF_UUID = "uuid"
-
 TO_REDACT = {
     "address",
     "full_location",

--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -6,7 +6,6 @@ import datetime
 import logging
 import re
 from dataclasses import dataclass
-from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
@@ -39,35 +38,11 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_MANUAL_RUNTIME = timedelta(minutes=5)
-
-PROGRAM_SMART_WATERING = "e"
-PROGRAM_MANUAL = "manual"
-
-ATTR_MANUAL_RUNTIME = "manual_preset_runtime"
-ATTR_SMART_WATERING_ENABLED = "smart_watering_enabled"
-ATTR_SPRINKLER_TYPE = "sprinkler_type"
-ATTR_IMAGE_URL = "image_url"
-ATTR_STARTED_WATERING_AT = "started_watering_station_at"
-ATTR_SMART_WATERING_PLAN = "watering_program"
-ATTR_CURRENT_STATION = "current_station"
-ATTR_CURRENT_PROGRAM = "current_program"
-ATTR_CURRENT_RUNTIME = "current_runtime"
-ATTR_NEXT_START_TIME = "next_start_time"
-ATTR_NEXT_START_PROGRAMS = "next_start_programs"
-
-# Service Attributes
-ATTR_MINUTES = "minutes"
-ATTR_HOURS = "hours"
-ATTR_PERCENTAGE = "percentage"
-
 # Rain Delay Attributes
 ATTR_CAUSE = "cause"
 ATTR_DELAY = "delay"
 ATTR_WEATHER_TYPE = "weather_type"
 ATTR_STARTED_AT = "started_at"
-
-ATTR_PROGRAM = "program_{}"
 
 # Keys accepted by the B-hyve API for program updates
 PROGRAM_UPDATE_KEYS = {

--- a/custom_components/bhyve/valve.py
+++ b/custom_components/bhyve/valve.py
@@ -40,9 +40,6 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_MANUAL_RUNTIME = timedelta(minutes=5)
 
-PROGRAM_SMART_WATERING = "e"
-PROGRAM_MANUAL = "manual"
-
 ATTR_MANUAL_RUNTIME = "manual_preset_runtime"
 ATTR_SMART_WATERING_ENABLED = "smart_watering_enabled"
 ATTR_SPRINKLER_TYPE = "sprinkler_type"


### PR DESCRIPTION
## Summary
Audited every module in `custom_components/bhyve/` for module-level constants with zero references anywhere in the codebase (including tests). Removed the dead ones.

- **switch.py**: `DEFAULT_MANUAL_RUNTIME`, `PROGRAM_SMART_WATERING`, `PROGRAM_MANUAL`, `ATTR_MANUAL_RUNTIME`, `ATTR_SMART_WATERING_ENABLED`, `ATTR_SPRINKLER_TYPE`, `ATTR_IMAGE_URL`, `ATTR_STARTED_WATERING_AT`, `ATTR_SMART_WATERING_PLAN`, `ATTR_CURRENT_STATION`, `ATTR_CURRENT_PROGRAM`, `ATTR_CURRENT_RUNTIME`, `ATTR_NEXT_START_TIME`, `ATTR_NEXT_START_PROGRAMS`, `ATTR_MINUTES`, `ATTR_HOURS`, `ATTR_PERCENTAGE`, `ATTR_PROGRAM`, plus the `timedelta` import
- **const.py**: `DEVICES`, `PROGRAMS`, `DATA_BHYVE`, `SIGNAL_UPDATE_DEVICE`, `SIGNAL_UPDATE_PROGRAM`, `TYPE_BINARY_SENSOR`, `TYPE_SENSOR`
- **diagnostics.py**: `CONF_ALTITUDE`, `CONF_UUID`
- **valve.py**: `PROGRAM_SMART_WATERING`, `PROGRAM_MANUAL`

Most were left over from the zone switch → valve migration. No runtime behaviour changes.

## Test plan
- [x] `./scripts/test` — 142 passed
- [x] `./scripts/lint` — all checks passed