### PR TITLE
Fix missing zone history and landscape data on multi-device accounts

### DIFF
--- a/custom_components/bhyve/pybhyve/client.py
+++ b/custom_components/bhyve/pybhyve/client.py
@@ -46,10 +46,10 @@ class BHyveClient:
         self._last_poll_programs = 0
 
         self._device_histories: dict[str, Any] = {}
-        self._last_poll_device_histories = 0
+        self._last_poll_device_histories: dict[str, float] = {}
 
-        self._landscapes: list[BHyveZoneLandscape] = []
-        self._last_poll_landscapes = 0
+        self._landscapes: dict[str, list[BHyveZoneLandscape]] = {}
+        self._last_poll_landscapes: dict[str, float] = {}
 
     async def _request(
         self,
@@ -129,7 +129,7 @@ class BHyveClient:
         now = time.time()
         if force_update:
             _LOGGER.info("Forcing refresh of device history %s", device_id)
-        elif now - self._last_poll_device_histories < API_POLL_PERIOD:
+        elif now - self._last_poll_device_histories.get(device_id, 0) < API_POLL_PERIOD:
             return
 
         device_history = await self._request(
@@ -144,7 +144,7 @@ class BHyveClient:
 
         self._device_histories.update({device_id: device_history})
 
-        self._last_poll_device_histories = now
+        self._last_poll_device_histories[device_id] = now
 
     async def _refresh_landscapes(
         self, device_id: str, *, force_update: bool = False
@@ -152,16 +152,17 @@ class BHyveClient:
         now = time.time()
         if force_update:
             _LOGGER.debug("Forcing landscape refresh %s", device_id)
-        elif now - self._last_poll_landscapes < API_POLL_PERIOD:
+        elif now - self._last_poll_landscapes.get(device_id, 0) < API_POLL_PERIOD:
             return
 
-        self._landscapes: list[BHyveZoneLandscape] = await self._request(
+        device_landscapes = await self._request(
             "get",
             f"{LANDSCAPE_DESCRIPTIONS_PATH}/{device_id}",
             params={"t": str(time.time())},
         )
 
-        self._last_poll_landscapes = now
+        self._landscapes[device_id] = device_landscapes or []
+        self._last_poll_landscapes[device_id] = now
 
     async def _async_ws_handler(self, async_callback: Callable, data: Any) -> None:
         """Process incoming websocket message."""
@@ -247,7 +248,7 @@ class BHyveClient:
     ) -> BHyveZoneLandscape | None:
         """Get landscape by zone id."""
         await self._refresh_landscapes(device_id, force_update=force_update)
-        for zone in self._landscapes:
+        for zone in self._landscapes.get(device_id, []):
             if zone.get("station") == zone_id:
                 return zone
         return None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,108 @@
+"""Test BHyve pybhyve client."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.bhyve.pybhyve.client import BHyveClient
+
+
+@pytest.fixture
+def client() -> BHyveClient:
+    """Create a BHyveClient with a mocked session."""
+    session = MagicMock()
+    return BHyveClient("user", "pass", session)
+
+
+class TestRefreshDeviceHistory:
+    """Test per-device rate limiting of history refresh."""
+
+    async def test_fetches_history_for_each_device(self, client: BHyveClient) -> None:
+        """
+        Back-to-back calls for different devices must each fetch history.
+
+        Regression test for issue #393: a shared rate-limit timestamp caused
+        the second sprinkler_timer in a multi-device account to never have
+        its history populated, so its zone history sensor stayed unknown.
+        """
+        client._request = AsyncMock(
+            side_effect=lambda *_args, **_kwargs: [{"fetched_for": "ok"}]
+        )
+
+        await client._refresh_device_history("device-a")
+        await client._refresh_device_history("device-b")
+
+        assert client._request.await_count == 2
+        assert "device-a" in client._device_histories
+        assert "device-b" in client._device_histories
+
+    async def test_rate_limits_same_device(self, client: BHyveClient) -> None:
+        """A second call for the same device within the poll period is skipped."""
+        client._request = AsyncMock(return_value=[{"fetched_for": "ok"}])
+
+        await client._refresh_device_history("device-a")
+        await client._refresh_device_history("device-a")
+
+        assert client._request.await_count == 1
+
+    async def test_force_update_bypasses_rate_limit(self, client: BHyveClient) -> None:
+        """force_update=True refetches even within the poll period."""
+        client._request = AsyncMock(return_value=[{"fetched_for": "ok"}])
+
+        await client._refresh_device_history("device-a")
+        await client._refresh_device_history("device-a", force_update=True)
+
+        assert client._request.await_count == 2
+
+
+class TestGetLandscape:
+    """Test per-device landscape fetching and caching."""
+
+    async def test_fetches_landscapes_for_each_device(
+        self, client: BHyveClient
+    ) -> None:
+        """
+        Back-to-back landscape fetches for different devices must each hit the API.
+
+        Regression test for the same-shape bug as issue #393 on the landscape
+        refresh path: a shared rate-limit timestamp and shared landscapes list
+        meant only the last-fetched device's data survived.
+        """
+        device_a_landscape = [{"station": 1, "device_id": "device-a"}]
+        device_b_landscape = [{"station": 1, "device_id": "device-b"}]
+        client._request = AsyncMock(
+            side_effect=[device_a_landscape, device_b_landscape]
+        )
+
+        zone_a = await client.get_landscape("device-a", 1)
+        zone_b = await client.get_landscape("device-b", 1)
+
+        assert client._request.await_count == 2
+        assert zone_a == {"station": 1, "device_id": "device-a"}
+        assert zone_b == {"station": 1, "device_id": "device-b"}
+
+    async def test_does_not_return_another_devices_landscape(
+        self, client: BHyveClient
+    ) -> None:
+        """A zone lookup must only search within the requested device's landscapes."""
+        client._request = AsyncMock(
+            side_effect=[
+                [{"station": 1, "device_id": "device-a"}],
+                [{"station": 2, "device_id": "device-b"}],
+            ]
+        )
+
+        await client.get_landscape("device-a", 1)
+        # device-b has no station 1 — must not fall back to device-a's entry
+        result = await client.get_landscape("device-b", 1)
+
+        assert result is None
+
+    async def test_rate_limits_same_device(self, client: BHyveClient) -> None:
+        """A second landscape call for the same device within the period is skipped."""
+        client._request = AsyncMock(return_value=[{"station": 1}])
+
+        await client.get_landscape("device-a", 1)
+        await client.get_landscape("device-a", 1)
+
+        assert client._request.await_count == 1


### PR DESCRIPTION
## Summary

Fixes #393. On accounts with more than one `sprinkler_timer`, zone history for every device after the first showed `unknown` starting in 4.0.0.

**Root cause:** `_last_poll_device_histories` and `_last_poll_landscapes` in `pybhyve/client.py` were single scalar timestamps shared across all devices. The 4.0.0 coordinator fetches history/landscapes for each sprinkler sequentially on every tick — the first device updates the stamp, subsequent devices bail out at the rate-limit check milliseconds later, and their entries are never populated in `_device_histories`. `get_device_history()` then returns `None` → coordinator converts to `[]` → zone history sensor renders `unknown`.

Landscapes had the same shared-timestamp bug **plus** `self._landscapes` was a single list overwritten on each per-device fetch, so only the last device's landscape data survived regardless.

**Fix:** key both the state and the timestamps by `device_id`.

## Test plan

- [x] New `tests/test_client.py` covers:
  - Back-to-back history fetches for different devices each hit the API (regression for #393)
  - Same-device history fetch is rate-limited within the poll period
  - `force_update=True` bypasses the rate limit
  - Landscape fetches for different devices are both served
  - A zone lookup for one device does not fall through to another device's landscape list
  - Same-device landscape fetch is rate-limited
- [x] Full suite: 148 passed, 5 skipped
- [x] `ruff check` / `ruff format --check` clean