### PR TITLE
Pick latest zone history irrigation by start_time

### DIFF
--- a/custom_components/bhyve/sensor.py
+++ b/custom_components/bhyve/sensor.py
@@ -367,59 +367,56 @@ class BHyveZoneHistorySensor(BHyveCoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> datetime | None:
         """Return the state of the entity."""
-        history = self._get_device_history()
-        if not history:
+        latest = self._get_latest_irrigation()
+        if not latest:
             return None
-
-        for history_item in history:
-            zone_irrigation = list(
-                filter(
-                    lambda i: i.get("station") == self._zone_id,
-                    history_item.get(ATTR_IRRIGATION, []),
-                )
-            )
-            if zone_irrigation:
-                # This is a bit crude - assumes the list is ordered by time.
-                latest_irrigation = zone_irrigation[-1]
-                start_time = latest_irrigation.get("start_time")
-                if start_time:
-                    local_time = orbit_time_to_local_time(start_time)
-                    if local_time:
-                        return local_time
+        start_time = latest.get(ATTR_START_TIME)
+        if start_time:
+            return orbit_time_to_local_time(start_time)
         return None
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
-        history = self._get_device_history()
-        if not history:
+        latest = self._get_latest_irrigation()
+        if not latest:
             return {}
 
-        for history_item in history:
-            zone_irrigation = list(
-                filter(
-                    lambda i: i.get("station") == self._zone_id,
-                    history_item.get(ATTR_IRRIGATION, []),
-                )
-            )
-            if zone_irrigation:
-                # This is a bit crude - assumes the list is ordered by time.
-                latest_irrigation = zone_irrigation[-1]
+        gallons = latest.get("water_volume_gal")
+        litres = round(gallons * 3.785, 2) if gallons else None
 
-                gallons = latest_irrigation.get("water_volume_gal")
-                litres = round(gallons * 3.785, 2) if gallons else None
+        return {
+            ATTR_BUDGET: latest.get(ATTR_BUDGET),
+            ATTR_PROGRAM: latest.get(ATTR_PROGRAM),
+            ATTR_PROGRAM_NAME: latest.get(ATTR_PROGRAM_NAME),
+            ATTR_RUN_TIME: latest.get(ATTR_RUN_TIME),
+            ATTR_STATUS: latest.get(ATTR_STATUS),
+            ATTR_CONSUMPTION_GALLONS: gallons,
+            ATTR_CONSUMPTION_LITRES: litres,
+            ATTR_START_TIME: latest.get(ATTR_START_TIME),
+        }
 
-                return {
-                    ATTR_BUDGET: latest_irrigation.get(ATTR_BUDGET),
-                    ATTR_PROGRAM: latest_irrigation.get(ATTR_PROGRAM),
-                    ATTR_PROGRAM_NAME: latest_irrigation.get(ATTR_PROGRAM_NAME),
-                    ATTR_RUN_TIME: latest_irrigation.get(ATTR_RUN_TIME),
-                    ATTR_STATUS: latest_irrigation.get(ATTR_STATUS),
-                    ATTR_CONSUMPTION_GALLONS: gallons,
-                    ATTR_CONSUMPTION_LITRES: litres,
-                    ATTR_START_TIME: latest_irrigation.get(ATTR_START_TIME),
-                }
-        return {}
+    def _get_latest_irrigation(self) -> dict | None:
+        """
+        Return the irrigation entry with the greatest start_time for this zone.
+
+        All statuses are considered — skipped runs can still report flow
+        consumption. Ordering is derived from start_time rather than array
+        position so we don't depend on how the upstream API sorts entries.
+        """
+        latest: dict | None = None
+        latest_start: str | None = None
+        for history_item in self._get_device_history():
+            for irrigation in history_item.get(ATTR_IRRIGATION, []):
+                if irrigation.get("station") != self._zone_id:
+                    continue
+                start_time = irrigation.get(ATTR_START_TIME)
+                if not start_time:
+                    continue
+                if latest_start is None or start_time > latest_start:
+                    latest_start = start_time
+                    latest = irrigation
+        return latest
 
     def _get_device_history(self) -> list:
         """Get device history from coordinator."""

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -125,7 +125,7 @@ def mock_zone_history_data() -> list:
                     "program": "a",
                     "program_name": "Morning Schedule",
                     "run_time": 15,
-                    "status": "completed",
+                    "status": "complete",
                     "water_volume_gal": 25.5,
                     "start_time": "2020-01-09T20:15:00.000Z",
                 }
@@ -461,9 +461,96 @@ class TestBHyveZoneHistorySensor:
         assert attrs["program"] == "a"
         assert attrs["program_name"] == "Morning Schedule"
         assert attrs["run_time"] == 15
-        assert attrs["status"] == "completed"
+        assert attrs["status"] == "complete"
         assert attrs["consumption_gallons"] == 25.5
         assert attrs["consumption_litres"] == 96.52
+
+    async def test_zone_history_sensor_picks_greatest_start_time(
+        self,
+        mock_sprinkler_device_with_battery: BHyveDevice,
+    ) -> None:
+        """Selection is by greatest start_time across all irrigation entries.
+
+        Skipped runs are not filtered — they still report consumption. The
+        latest entry by timestamp wins regardless of array position or which
+        history item it lives in.
+        """
+        history = [
+            {
+                "irrigation": [
+                    {
+                        "station": "1",
+                        "budget": 100,
+                        "program": "e",
+                        "program_name": "Smart Watering",
+                        "run_time": 24,
+                        "status": "complete",
+                        "water_volume_gal": None,
+                        "start_time": "2026-04-18T20:00:00.000Z",
+                    },
+                    {
+                        "station": "1",
+                        "budget": 100,
+                        "program": "manual",
+                        "program_name": "manual",
+                        "run_time": 0.97,
+                        "status": "skipped",
+                        "water_volume_gal": 2,
+                        "start_time": "2026-04-19T04:36:14.000Z",
+                    },
+                ]
+            },
+            {
+                "irrigation": [
+                    {
+                        "station": "1",
+                        "budget": 100,
+                        "program": "e",
+                        "program_name": "Smart Watering",
+                        "run_time": 22,
+                        "status": "complete",
+                        "water_volume_gal": 69,
+                        "start_time": "2026-04-16T20:00:04.000Z",
+                    }
+                ]
+            },
+        ]
+        coordinator = create_mock_coordinator(
+            {
+                "test-device-123": {
+                    "device": mock_sprinkler_device_with_battery,
+                    "history": history,
+                    "landscapes": {},
+                }
+            }
+        )
+
+        description = SensorEntityDescription(
+            key="zone_history",
+            translation_key="zone_history",
+            icon="mdi:history",
+            device_class=SensorDeviceClass.TIMESTAMP,
+            entity_category=EntityCategory.DIAGNOSTIC,
+        )
+        sensor = BHyveZoneHistorySensor(
+            coordinator=coordinator,
+            device=mock_sprinkler_device_with_battery,
+            zone={"station": "1", "name": "Front Lawn"},
+            zone_name="Front Lawn",
+            description=description,
+        )
+
+        # Greatest start_time is the 2026-04-19 manual skipped run.
+        assert sensor.native_value is not None
+        assert sensor.native_value.day == 19
+        assert sensor.native_value.hour == 4
+
+        attrs = sensor.extra_state_attributes
+        assert attrs["program"] == "manual"
+        assert attrs["status"] == "skipped"
+        assert attrs["run_time"] == 0.97
+        assert attrs["consumption_gallons"] == 2
+        assert attrs["consumption_litres"] == 7.57
 
 
 class TestSensorWebsocketEvents:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -469,7 +469,8 @@ class TestBHyveZoneHistorySensor:
         self,
         mock_sprinkler_device_with_battery: BHyveDevice,
     ) -> None:
-        """Selection is by greatest start_time across all irrigation entries.
+        """
+        Selection is by greatest start_time across all irrigation entries.
 
         Skipped runs are not filtered — they still report consumption. The
         latest entry by timestamp wins regardless of array position or which


### PR DESCRIPTION
## Summary
- Zone history sensor previously picked `zone_irrigation[-1]` from the first history item containing any entry for the zone. That relied on the upstream `irrigation` array being ordered by time, which isn't always true — a later entry appearing earlier in the array caused the sensor to surface the wrong run (wrong `start_time`, `run_time`, `status`, `consumption_gallons`, `consumption_litres`).
- Now selects the irrigation entry with the greatest `start_time` across all history items. All statuses are considered so skipped runs still report their flow consumption.

## Test plan
- [x] `pytest tests/test_sensor.py` — all 11 tests pass, including a new case that asserts selection is by greatest `start_time` regardless of array position or history-item position.
- [x] `./scripts/lint` — clean.