### PR TITLE
Add regression tests for issue #306 zone toggle

### DIFF
--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -232,3 +232,75 @@ class TestDeviceEventHandling:
         ]["watering_status"]
         assert watering_status["current_station"] == 1
         assert watering_status["stations"] == [{"station": 1, "run_time": 14}]
+
+    async def test_change_mode_auto_preserves_watering_status(
+        self, hass: HomeAssistant
+    ) -> None:
+        """
+        Issue #306: change_mode auto must not clear active watering_status.
+
+        Reproduces the event sequence from the user's log:
+        1. watering_in_progress_notification arrives (zone 1 starts watering)
+        2. change_mode with mode=auto arrives ~1s later
+
+        Previously, when zone entities were switches, the change_mode handler
+        set is_on=False on all zone switches, producing the on/off toggle
+        reported in the issue. Verify that the coordinator does not wipe the
+        watering_status on change_mode so valve entities stay open.
+        """
+        coordinator = create_mock_coordinator(hass)
+
+        watering_event = {
+            "event": "watering_in_progress_notification",
+            "device_id": TEST_DEVICE_ID,
+            "program": "a",
+            "current_station": 1,
+            "run_time": 49.98,
+            "total_run_time_sec": 3000,
+            "started_watering_station_at": "2025-05-27T10:00:03.000Z",
+            "timestamp": "2025-05-27T10:00:04.000Z",
+            "status": "watering_in_progress",
+            "rain_sensor_hold": False,
+        }
+        change_mode_event = {
+            "event": "change_mode",
+            "mode": "auto",
+            "device_id": TEST_DEVICE_ID,
+            "timestamp": "2025-05-27T10:00:04.000Z",
+        }
+
+        with patch.object(coordinator, "async_set_updated_data"):
+            await coordinator.async_handle_device_event(watering_event)
+            await coordinator.async_handle_device_event(change_mode_event)
+
+        status = coordinator.data["devices"][TEST_DEVICE_ID]["device"]["status"]
+        assert "watering_status" in status
+        assert status["watering_status"]["current_station"] == 1
+        assert status["watering_status"]["program"] == "a"
+
+    async def test_device_idle_clears_watering_status(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Device_idle must clear watering_status so the valve closes."""
+        coordinator = create_mock_coordinator(hass)
+
+        with patch.object(coordinator, "async_set_updated_data"):
+            await coordinator.async_handle_device_event(
+                {
+                    "event": "watering_in_progress_notification",
+                    "device_id": TEST_DEVICE_ID,
+                    "program": "a",
+                    "current_station": 1,
+                    "run_time": 14,
+                }
+            )
+            await coordinator.async_handle_device_event(
+                {
+                    "event": "device_idle",
+                    "device_id": TEST_DEVICE_ID,
+                }
+            )
+
+        status = coordinator.data["devices"][TEST_DEVICE_ID]["device"]["status"]
+        assert "watering_status" not in status
+        assert status["run_mode"] == "off"

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -1,8 +1,9 @@
 """Test BHyve valve entities."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.core import HomeAssistant
 
 from custom_components.bhyve.coordinator import BHyveDataUpdateCoordinator
 from custom_components.bhyve.pybhyve.typings import BHyveDevice, BHyveZone
@@ -444,3 +445,79 @@ async def test_valve_set_manual_preset_runtime(
     coordinator.client.set_manual_preset_runtime.assert_called_once_with(
         mock_sprinkler_device["id"], 8
     )
+
+
+async def test_valve_does_not_toggle_on_change_mode_during_watering(
+    hass: HomeAssistant,
+    mock_sprinkler_device: BHyveDevice,
+    mock_zone_data: BHyveZone,
+) -> None:
+    """
+    Regression for issue #306: valve must not close mid-watering.
+
+    The B-hyve cloud interleaves a `change_mode` (mode=auto) event right after
+    `watering_in_progress_notification` when a program starts. In the old
+    switch-based implementation this flipped the zone switch off/on and showed
+    up as a brief toggle. Drive the real coordinator through that event
+    sequence and assert the valve stays open the whole time.
+    """
+    client = MagicMock()
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    coordinator = BHyveDataUpdateCoordinator(hass, client, entry)
+    device_id = mock_sprinkler_device["id"]
+    coordinator.data = {
+        "devices": {
+            device_id: {
+                "device": dict(mock_sprinkler_device),
+                "history": [],
+                "landscapes": {},
+            }
+        },
+        "programs": {},
+    }
+    coordinator.client = MagicMock()
+    coordinator.client.send_message = AsyncMock()
+
+    valve = BHyveZoneValve(
+        coordinator=coordinator,
+        device=coordinator.data["devices"][device_id]["device"],
+        zone=mock_zone_data,
+        zone_name="Front Yard",
+        device_programs=[],
+    )
+
+    assert valve.is_closed is True
+
+    with patch.object(coordinator, "async_set_updated_data"):
+        await coordinator.async_handle_device_event(
+            {
+                "event": "watering_in_progress_notification",
+                "device_id": device_id,
+                "program": "a",
+                "current_station": "1",
+                "run_time": 49.98,
+                "total_run_time_sec": 3000,
+                "started_watering_station_at": "2025-05-27T10:00:03.000Z",
+            }
+        )
+        assert valve.is_closed is False, "valve should open when watering starts"
+
+        await coordinator.async_handle_device_event(
+            {
+                "event": "change_mode",
+                "mode": "auto",
+                "device_id": device_id,
+            }
+        )
+        assert valve.is_closed is False, (
+            "valve must stay open after change_mode mode=auto (issue #306)"
+        )
+
+        await coordinator.async_handle_device_event(
+            {
+                "event": "device_idle",
+                "device_id": device_id,
+            }
+        )
+        assert valve.is_closed is True, "valve should close when device_idle arrives"


### PR DESCRIPTION
## Summary
- Pin the event sequence reported in #306 with coordinator and valve-level tests.
- In the old switch-based zone entity, a `change_mode` with `mode=auto` (which B-hyve emits ~1s after `watering_in_progress_notification` at program start) set `is_on = False` on every zone, producing the visible on/off toggle.
- The valve migration in #240 moved state derivation to the coordinator — `EVENT_CHANGE_MODE` now only merges new keys onto `status` and never touches `watering_status`. The scenario was never pinned by tests; this PR adds them.

## Test plan
- [x] `pytest tests/test_coordinator.py::TestDeviceEventHandling -v`
- [x] `pytest tests/test_valve.py::test_valve_does_not_toggle_on_change_mode_during_watering -v`
- [x] `pytest tests/` (152 passed, 5 skipped)