### PR TITLE
Support enable/disable_rain_delay services on rain delay switch

### DIFF
--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -480,8 +480,16 @@ class BHyveRainDelaySwitch(BHyveCoordinatorEntity, SwitchEntity):
 
     async def async_turn_on(self, **_kwargs: Any) -> None:
         """Turn the switch on."""
-        await self.coordinator.client.set_rain_delay(self._device_id, 24)
+        await self.enable_rain_delay()
 
     async def async_turn_off(self, **_kwargs: Any) -> None:
         """Turn the switch off."""
+        await self.disable_rain_delay()
+
+    async def enable_rain_delay(self, hours: int = 24) -> None:
+        """Enable rain delay for the device."""
+        await self.coordinator.client.set_rain_delay(self._device_id, hours)
+
+    async def disable_rain_delay(self) -> None:
+        """Disable rain delay for the device."""
         await self.coordinator.client.set_rain_delay(self._device_id, 0)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -849,6 +849,44 @@ class TestBHyveRainDelaySwitch:
         # Verify set_rain_delay was called with 0 hours to disable
         coordinator.client.set_rain_delay.assert_called_once_with(TEST_DEVICE_ID, 0)
 
+    async def test_rain_delay_switch_enable_rain_delay(
+        self,
+        mock_sprinkler_device: BHyveDevice,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        """Test enable_rain_delay service method honours custom hours."""
+        description = create_rain_delay_switch_description(mock_sprinkler_device)
+        switch = BHyveRainDelaySwitch(
+            coordinator=mock_coordinator,
+            device=mock_sprinkler_device,
+            description=description,
+        )
+
+        await switch.enable_rain_delay(hours=5)
+
+        mock_coordinator.client.set_rain_delay.assert_called_once_with(
+            TEST_DEVICE_ID, 5
+        )
+
+    async def test_rain_delay_switch_disable_rain_delay(
+        self,
+        mock_sprinkler_device: BHyveDevice,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        """Test disable_rain_delay service method clears the delay."""
+        description = create_rain_delay_switch_description(mock_sprinkler_device)
+        switch = BHyveRainDelaySwitch(
+            coordinator=mock_coordinator,
+            device=mock_sprinkler_device,
+            description=description,
+        )
+
+        await switch.disable_rain_delay()
+
+        mock_coordinator.client.set_rain_delay.assert_called_once_with(
+            TEST_DEVICE_ID, 0
+        )
+
     async def test_rain_delay_switch_websocket_event(
         self,
         mock_sprinkler_device: BHyveDevice,


### PR DESCRIPTION
## Summary

Fixes #407.

`bhyve.enable_rain_delay` / `bhyve.disable_rain_delay` are registered by the valve platform, and since #391 the service handler routes calls through both `VALVE_DOMAIN` and `SWITCH_DOMAIN` — but the corresponding methods were only ported onto `BHyveZoneValve`. Calling `bhyve.enable_rain_delay` with a rain-delay switch entity (the natural target) therefore logged `Service enable_rain_delay is not supported by entity switch.<device>_rain_delay` and the requested hours were silently dropped.

- Add `enable_rain_delay(hours: int = 24)` and `disable_rain_delay()` to `BHyveRainDelaySwitch`, delegating to `coordinator.client.set_rain_delay`.
- Route `async_turn_on` / `async_turn_off` through these methods so there's one path to the client.
- Add regression tests covering both service methods with custom hours and the zero-hour disable.

## Test plan

- [x] `./scripts/lint`
- [x] `pytest tests/` — 155 passed, 5 skipped (new `test_rain_delay_switch_enable_rain_delay` / `test_rain_delay_switch_disable_rain_delay` pass)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VDPk1Mucj3NMBvqsEeJmqE)_