### PR TITLE
4.0.2

### DIFF
--- a/custom_components/bhyve/manifest.json
+++ b/custom_components/bhyve/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/sebr/bhyve-home-assistant/issues",
-  "version": "4.0.1"
+  "version": "4.0.2"
 }


### PR DESCRIPTION
## Summary

Patch release bumping the integration version from 4.0.1 to 4.0.2 in `custom_components/bhyve/manifest.json`.

Includes changes merged since 4.0.1:
- Support enable/disable_rain_delay services on rain delay switch (#408)
- Bump ruff from 0.15.10 to 0.15.11 (#402)

## Test plan

- [ ] CI passes


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jee3cR7LR85Ey3UdM5kDRc)_