### PR TITLE
Add next_watering timestamp sensor per device

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ _Note_: The Wifi hub is required to provide the flood sensors with internet conn
 ## Supported Entities
 
 - `valve` for opening/closing individual zones on `sprinkler_timer` devices.
-- `sensor` for battery levels, zone watering history, zone next watering time, device run-mode state, flood-sensor temperature and flood-sensor signal strength.
+- `sensor` for battery levels, zone watering history, device next watering time, device run-mode state, flood-sensor temperature and flood-sensor signal strength.
 - `switch` for enabling/disabling rain delays, toggling pre-configured programs and enabling/disabling per-zone smart watering.
 - `select` for the device run-mode (auto/off) on `sprinkler_timer` devices.
 - `binary_sensor` for flood detection, temperature alerts, sprinkler station faults and Wi-Fi bridge connectivity.
@@ -94,17 +94,17 @@ The following attributes are set on zone history sensor entities:
 | `consumption_litres`  | `number` | The amount of water consumed, in litres.                    |
 | `start_time`          | `string` | The start time of the watering.                             |
 
-### Zone Next Watering sensor
+### Device Next Watering sensor
 
-A **next watering** `sensor` entity is created for each zone on a `sprinkler_timer` device. This reports the next scheduled watering time as a timestamp, allowing relative-time rendering ("in 14 hours"), long-term statistics, and direct use in automations and dashboard cards.
+A **next watering** `sensor` entity is created for each `sprinkler_timer` device. This reports the next scheduled watering time as a timestamp, allowing relative-time rendering ("in 14 hours"), long-term statistics, and direct use in automations and dashboard cards.
 
 The existing `next_start_time` valve attribute is preserved for backward compatibility.
 
 The following attributes are set on next watering sensor entities:
 
-| Attribute  | Type           | Notes                                           |
-| ---------- | -------------- | ----------------------------------------------- |
-| `programs` | `list[string]` | The programs scheduled to run at this time.     |
+| Attribute  | Type           | Notes                                                          |
+| ---------- | -------------- | -------------------------------------------------------------- |
+| `programs` | `list[string]` | The programs scheduled to run at this time, if any.            |
 
 ### Temperature sensor
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ _Note_: The Wifi hub is required to provide the flood sensors with internet conn
 ## Supported Entities
 
 - `valve` for opening/closing individual zones on `sprinkler_timer` devices.
-- `sensor` for battery levels, zone watering history, device run-mode state, flood-sensor temperature and flood-sensor signal strength.
+- `sensor` for battery levels, zone watering history, zone next watering time, device run-mode state, flood-sensor temperature and flood-sensor signal strength.
 - `switch` for enabling/disabling rain delays, toggling pre-configured programs and enabling/disabling per-zone smart watering.
 - `select` for the device run-mode (auto/off) on `sprinkler_timer` devices.
 - `binary_sensor` for flood detection, temperature alerts, sprinkler station faults and Wi-Fi bridge connectivity.
@@ -93,6 +93,18 @@ The following attributes are set on zone history sensor entities:
 | `consumption_gallons` | `number` | The amount of water consumed, in gallons.                   |
 | `consumption_litres`  | `number` | The amount of water consumed, in litres.                    |
 | `start_time`          | `string` | The start time of the watering.                             |
+
+### Zone Next Watering sensor
+
+A **next watering** `sensor` entity is created for each zone on a `sprinkler_timer` device. This reports the next scheduled watering time as a timestamp, allowing relative-time rendering ("in 14 hours"), long-term statistics, and direct use in automations and dashboard cards.
+
+The existing `next_start_time` valve attribute is preserved for backward compatibility.
+
+The following attributes are set on next watering sensor entities:
+
+| Attribute  | Type           | Notes                                           |
+| ---------- | -------------- | ----------------------------------------------- |
+| `programs` | `list[string]` | The programs scheduled to run at this time.     |
 
 ### Temperature sensor
 

--- a/custom_components/bhyve/sensor.py
+++ b/custom_components/bhyve/sensor.py
@@ -443,5 +443,3 @@ class BHyveZoneHistorySensor(BHyveCoordinatorEntity, SensorEntity):
             .get(self._device_id, {})
             .get("history", [])
         )
-
-

--- a/custom_components/bhyve/sensor.py
+++ b/custom_components/bhyve/sensor.py
@@ -104,22 +104,21 @@ SENSOR_TYPES_SPRINKLER: tuple[BHyveSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data.get("status", {}).get("run_mode", "unavailable"),
     ),
-)
-
-SENSOR_TYPES_ZONE: tuple[BHyveSensorEntityDescription, ...] = (
     BHyveSensorEntityDescription(
         key="next_watering",
         translation_key="next_watering",
+        name="Next watering",
         unique_id_suffix="next_watering",
         device_class=SensorDeviceClass.TIMESTAMP,
         icon="mdi:sprinkler-variant",
-        entity_registry_enabled_default=False,
         value_fn=lambda data: orbit_time_to_local_time(
             data.get("status", {}).get("next_start_time")
         ),
-        attributes_fn=lambda data: {
-            ATTR_NEXT_START_PROGRAMS: data.get("status", {}).get("next_start_programs"),
-        },
+        attributes_fn=lambda data: (
+            {ATTR_NEXT_START_PROGRAMS: programs}
+            if (programs := data.get("status", {}).get("next_start_programs"))
+            else {}
+        ),
     ),
 )
 
@@ -206,6 +205,7 @@ async def async_setup_entry(
                     name=base_description.name,
                     icon=base_description.icon,
                     unique_id_suffix=base_description.unique_id_suffix,
+                    device_class=base_description.device_class,
                     entity_category=base_description.entity_category,
                     value_fn=base_description.value_fn,
                     attributes_fn=base_description.attributes_fn,
@@ -239,18 +239,6 @@ async def async_setup_entry(
                         ),
                     )
                 )
-
-                # Add per-zone sensors (next watering, etc.)
-                for base_description in SENSOR_TYPES_ZONE:
-                    sensors.append(  # noqa: PERF401
-                        BHyveZoneSensor(
-                            coordinator,
-                            device,
-                            zone,
-                            zone_name,
-                            base_description,
-                        )
-                    )
 
             # Add battery sensor if device has battery
             if device.get("battery", None) is not None:
@@ -335,7 +323,7 @@ class BHyveSensor(BHyveCoordinatorEntity, SensorEntity):
         )
 
     @property
-    def native_value(self) -> int | float | str | None:
+    def native_value(self) -> datetime | int | float | str | None:
         """Return the state of the entity."""
         if self.entity_description.value_fn:
             return self.entity_description.value_fn(self.device_data)
@@ -457,45 +445,3 @@ class BHyveZoneHistorySensor(BHyveCoordinatorEntity, SensorEntity):
         )
 
 
-class BHyveZoneSensor(BHyveCoordinatorEntity, SensorEntity):
-    """Define a BHyve per-zone sensor."""
-
-    entity_description: BHyveSensorEntityDescription
-    _attr_has_entity_name = True
-    _attr_entity_registry_enabled_default = False
-
-    def __init__(
-        self,
-        coordinator: BHyveDataUpdateCoordinator,
-        device: BHyveDevice,
-        zone: dict,
-        zone_name: str,
-        description: BHyveSensorEntityDescription,
-    ) -> None:
-        """Initialize the sensor."""
-        self.entity_description = description
-        friendly = description.key.replace("_", " ").title()
-        if zone_name == device.get("name"):
-            self._attr_name = friendly
-        else:
-            self._attr_name = f"{zone_name} {friendly}"
-        super().__init__(coordinator, device)
-        self._zone = zone
-        self._zone_id = zone.get("station")
-        self._attr_unique_id = (
-            f"{self._mac_address}:{self._device_id}:{self._zone_id}:{description.unique_id_suffix}"
-        )
-
-    @property
-    def native_value(self) -> datetime | None:
-        """Return the state of the entity."""
-        if self.entity_description.value_fn:
-            return self.entity_description.value_fn(self.device_data)
-        return None
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return the device state attributes."""
-        if self.entity_description.attributes_fn:
-            return self.entity_description.attributes_fn(self.device_data)
-        return {}

--- a/custom_components/bhyve/sensor.py
+++ b/custom_components/bhyve/sensor.py
@@ -44,6 +44,7 @@ ATTR_IRRIGATION = "irrigation"
 ATTR_PROGRAM = "program"
 ATTR_PROGRAM_NAME = "program_name"
 ATTR_RUN_TIME = "run_time"
+ATTR_NEXT_START_PROGRAMS = "programs"
 ATTR_START_TIME = "start_time"
 ATTR_STATUS = "status"
 
@@ -102,6 +103,23 @@ SENSOR_TYPES_SPRINKLER: tuple[BHyveSensorEntityDescription, ...] = (
         unique_id_suffix="state",
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data.get("status", {}).get("run_mode", "unavailable"),
+    ),
+)
+
+SENSOR_TYPES_ZONE: tuple[BHyveSensorEntityDescription, ...] = (
+    BHyveSensorEntityDescription(
+        key="next_watering",
+        translation_key="next_watering",
+        unique_id_suffix="next_watering",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        icon="mdi:sprinkler-variant",
+        entity_registry_enabled_default=False,
+        value_fn=lambda data: orbit_time_to_local_time(
+            data.get("status", {}).get("next_start_time")
+        ),
+        attributes_fn=lambda data: {
+            ATTR_NEXT_START_PROGRAMS: data.get("status", {}).get("next_start_programs"),
+        },
     ),
 )
 
@@ -221,6 +239,18 @@ async def async_setup_entry(
                         ),
                     )
                 )
+
+                # Add per-zone sensors (next watering, etc.)
+                for base_description in SENSOR_TYPES_ZONE:
+                    sensors.append(  # noqa: PERF401
+                        BHyveZoneSensor(
+                            coordinator,
+                            device,
+                            zone,
+                            zone_name,
+                            base_description,
+                        )
+                    )
 
             # Add battery sensor if device has battery
             if device.get("battery", None) is not None:
@@ -425,3 +455,47 @@ class BHyveZoneHistorySensor(BHyveCoordinatorEntity, SensorEntity):
             .get(self._device_id, {})
             .get("history", [])
         )
+
+
+class BHyveZoneSensor(BHyveCoordinatorEntity, SensorEntity):
+    """Define a BHyve per-zone sensor."""
+
+    entity_description: BHyveSensorEntityDescription
+    _attr_has_entity_name = True
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(
+        self,
+        coordinator: BHyveDataUpdateCoordinator,
+        device: BHyveDevice,
+        zone: dict,
+        zone_name: str,
+        description: BHyveSensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        self.entity_description = description
+        friendly = description.key.replace("_", " ").title()
+        if zone_name == device.get("name"):
+            self._attr_name = friendly
+        else:
+            self._attr_name = f"{zone_name} {friendly}"
+        super().__init__(coordinator, device)
+        self._zone = zone
+        self._zone_id = zone.get("station")
+        self._attr_unique_id = (
+            f"{self._mac_address}:{self._device_id}:{self._zone_id}:{description.unique_id_suffix}"
+        )
+
+    @property
+    def native_value(self) -> datetime | None:
+        """Return the state of the entity."""
+        if self.entity_description.value_fn:
+            return self.entity_description.value_fn(self.device_data)
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the device state attributes."""
+        if self.entity_description.attributes_fn:
+            return self.entity_description.attributes_fn(self.device_data)
+        return {}

--- a/custom_components/bhyve/strings.json
+++ b/custom_components/bhyve/strings.json
@@ -200,6 +200,9 @@
       "zone_history": {
         "name": "{zone_name} zone history"
       },
+      "next_watering": {
+        "name": "Next watering"
+      },
       "temperature": {
         "name": "Temperature"
       },

--- a/custom_components/bhyve/translations/en.json
+++ b/custom_components/bhyve/translations/en.json
@@ -184,6 +184,9 @@
       }
     },
     "sensor": {
+      "next_watering": {
+        "name": "Next watering"
+      },
       "temperature": {
         "name": "Temperature"
       },

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -16,9 +16,11 @@ from custom_components.bhyve.sensor import (
     SENSOR_TYPES_BATTERY,
     SENSOR_TYPES_FLOOD,
     SENSOR_TYPES_SPRINKLER,
+    SENSOR_TYPES_ZONE,
     BHyveSensor,
     BHyveSensorEntityDescription,
     BHyveZoneHistorySensor,
+    BHyveZoneSensor,
 )
 
 # Test constants
@@ -132,6 +134,29 @@ def mock_zone_history_data() -> list:
             ]
         }
     ]
+
+
+@pytest.fixture
+def mock_sprinkler_device_with_next_start_time() -> BHyveDevice:
+    """Mock BHyve sprinkler device with next_start_time in status."""
+    return BHyveDevice(
+        {
+            "id": "test-device-123",
+            "name": "Test Sprinkler",
+            "type": "sprinkler_timer",
+            "mac_address": "aa:bb:cc:dd:ee:ff",
+            "hardware_version": "v2.0",
+            "firmware_version": "1.2.3",
+            "is_connected": True,
+            "status": {
+                "run_mode": "auto",
+                "watering_status": None,
+                "next_start_time": "2026-05-01T03:30:00-07:00",
+                "next_start_programs": ["e"],
+            },
+            "zones": [{"station": "1", "name": "Front Lawn"}],
+        }
+    )
 
 
 class TestBHyveBatterySensor:
@@ -600,3 +625,98 @@ class TestSensorWebsocketEvents:
         # Sensors should be unavailable
         assert battery_sensor.available is False
         assert state_sensor.available is False
+
+
+class TestBHyveZoneSensor:
+    """Test BHyveZoneSensor entity (next watering)."""
+
+    async def test_next_watering_sensor_initialization(
+        self,
+        mock_sprinkler_device_with_battery: BHyveDevice,
+    ) -> None:
+        """Test next watering sensor entity initialization."""
+        coordinator = create_mock_coordinator(
+            {
+                "test-device-123": {
+                    "device": mock_sprinkler_device_with_battery,
+                    "history": [],
+                    "landscapes": {},
+                }
+            }
+        )
+
+        zone = {"station": "1", "name": "Front Lawn"}
+        sensor = BHyveZoneSensor(
+            coordinator=coordinator,
+            device=mock_sprinkler_device_with_battery,
+            zone=zone,
+            zone_name="Front Lawn",
+            description=SENSOR_TYPES_ZONE[0],
+        )
+
+        assert sensor._attr_name == "Front Lawn Next Watering"
+        assert sensor.device_class == SensorDeviceClass.TIMESTAMP
+        assert sensor._zone_id == "1"
+        assert sensor._attr_unique_id.endswith(":1:next_watering")
+
+    async def test_next_watering_sensor_with_scheduled_time(
+        self,
+        mock_sprinkler_device_with_next_start_time: BHyveDevice,
+    ) -> None:
+        """Test next watering sensor returns correct timestamp and programs attribute."""
+        coordinator = create_mock_coordinator(
+            {
+                "test-device-123": {
+                    "device": mock_sprinkler_device_with_next_start_time,
+                    "history": [],
+                    "landscapes": {},
+                }
+            }
+        )
+
+        zone = {"station": "1", "name": "Front Lawn"}
+        sensor = BHyveZoneSensor(
+            coordinator=coordinator,
+            device=mock_sprinkler_device_with_next_start_time,
+            zone=zone,
+            zone_name="Front Lawn",
+            description=SENSOR_TYPES_ZONE[0],
+        )
+
+        # Value should parse to a datetime
+        assert sensor.native_value is not None
+        assert sensor.native_value.year == 2026
+        assert sensor.native_value.month == 5
+        assert sensor.native_value.day == 1
+
+        # Programs attribute should reflect next_start_programs
+        attrs = sensor.extra_state_attributes
+        assert attrs["programs"] == ["e"]
+
+    async def test_next_watering_sensor_no_schedule(
+        self,
+        mock_sprinkler_device_with_battery: BHyveDevice,
+    ) -> None:
+        """Test next watering sensor returns None when next_start_time is absent."""
+        coordinator = create_mock_coordinator(
+            {
+                "test-device-123": {
+                    "device": mock_sprinkler_device_with_battery,
+                    "history": [],
+                    "landscapes": {},
+                }
+            }
+        )
+
+        zone = {"station": "1", "name": "Front Lawn"}
+        sensor = BHyveZoneSensor(
+            coordinator=coordinator,
+            device=mock_sprinkler_device_with_battery,
+            zone=zone,
+            zone_name="Front Lawn",
+            description=SENSOR_TYPES_ZONE[0],
+        )
+
+        # No next_start_time in status — should return None (HA renders as Unknown)
+        assert sensor.native_value is None
+        assert sensor.extra_state_attributes["programs"] is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -16,11 +16,9 @@ from custom_components.bhyve.sensor import (
     SENSOR_TYPES_BATTERY,
     SENSOR_TYPES_FLOOD,
     SENSOR_TYPES_SPRINKLER,
-    SENSOR_TYPES_ZONE,
     BHyveSensor,
     BHyveSensorEntityDescription,
     BHyveZoneHistorySensor,
-    BHyveZoneSensor,
 )
 
 # Test constants
@@ -138,7 +136,7 @@ def mock_zone_history_data() -> list:
 
 @pytest.fixture
 def mock_sprinkler_device_with_next_start_time() -> BHyveDevice:
-    """Mock BHyve sprinkler device with next_start_time in status."""
+    """Mock BHyve sprinkler device with next_start_time in device status."""
     return BHyveDevice(
         {
             "id": "test-device-123",
@@ -153,6 +151,27 @@ def mock_sprinkler_device_with_next_start_time() -> BHyveDevice:
                 "watering_status": None,
                 "next_start_time": "2026-05-01T03:30:00-07:00",
                 "next_start_programs": ["e"],
+            },
+            "zones": [{"station": "1", "name": "Front Lawn"}],
+        }
+    )
+
+
+@pytest.fixture
+def mock_sprinkler_device_no_schedule() -> BHyveDevice:
+    """Mock BHyve sprinkler device with no upcoming schedule."""
+    return BHyveDevice(
+        {
+            "id": "test-device-123",
+            "name": "Test Sprinkler",
+            "type": "sprinkler_timer",
+            "mac_address": "aa:bb:cc:dd:ee:ff",
+            "hardware_version": "v2.0",
+            "firmware_version": "1.2.3",
+            "is_connected": True,
+            "status": {
+                "run_mode": "auto",
+                "watering_status": None,
             },
             "zones": [{"station": "1", "name": "Front Lawn"}],
         }
@@ -627,43 +646,14 @@ class TestSensorWebsocketEvents:
         assert state_sensor.available is False
 
 
-class TestBHyveZoneSensor:
-    """Test BHyveZoneSensor entity (next watering)."""
+class TestBHyveNextWateringSensor:
+    """Test next watering device-level sensor (SENSOR_TYPES_SPRINKLER[1])."""
 
     async def test_next_watering_sensor_initialization(
         self,
-        mock_sprinkler_device_with_battery: BHyveDevice,
-    ) -> None:
-        """Test next watering sensor entity initialization."""
-        coordinator = create_mock_coordinator(
-            {
-                "test-device-123": {
-                    "device": mock_sprinkler_device_with_battery,
-                    "history": [],
-                    "landscapes": {},
-                }
-            }
-        )
-
-        zone = {"station": "1", "name": "Front Lawn"}
-        sensor = BHyveZoneSensor(
-            coordinator=coordinator,
-            device=mock_sprinkler_device_with_battery,
-            zone=zone,
-            zone_name="Front Lawn",
-            description=SENSOR_TYPES_ZONE[0],
-        )
-
-        assert sensor._attr_name == "Front Lawn Next Watering"
-        assert sensor.device_class == SensorDeviceClass.TIMESTAMP
-        assert sensor._zone_id == "1"
-        assert sensor._attr_unique_id.endswith(":1:next_watering")
-
-    async def test_next_watering_sensor_with_scheduled_time(
-        self,
         mock_sprinkler_device_with_next_start_time: BHyveDevice,
     ) -> None:
-        """Test next watering sensor returns correct timestamp and programs attribute."""
+        """Test next watering sensor entity initialization."""
         coordinator = create_mock_coordinator(
             {
                 "test-device-123": {
@@ -674,13 +664,41 @@ class TestBHyveZoneSensor:
             }
         )
 
-        zone = {"station": "1", "name": "Front Lawn"}
-        sensor = BHyveZoneSensor(
+        description = create_sensor_description(
+            mock_sprinkler_device_with_next_start_time, SENSOR_TYPES_SPRINKLER[1]
+        )
+        sensor = BHyveSensor(
             coordinator=coordinator,
             device=mock_sprinkler_device_with_next_start_time,
-            zone=zone,
-            zone_name="Front Lawn",
-            description=SENSOR_TYPES_ZONE[0],
+            description=description,
+        )
+
+        assert sensor.name == "Next watering"
+        assert sensor.device_class == SensorDeviceClass.TIMESTAMP
+        assert sensor._attr_unique_id.endswith(":next_watering")
+
+    async def test_next_watering_sensor_with_scheduled_time(
+        self,
+        mock_sprinkler_device_with_next_start_time: BHyveDevice,
+    ) -> None:
+        """Test next watering sensor returns correct timestamp and programs."""
+        coordinator = create_mock_coordinator(
+            {
+                "test-device-123": {
+                    "device": mock_sprinkler_device_with_next_start_time,
+                    "history": [],
+                    "landscapes": {},
+                }
+            }
+        )
+
+        description = create_sensor_description(
+            mock_sprinkler_device_with_next_start_time, SENSOR_TYPES_SPRINKLER[1]
+        )
+        sensor = BHyveSensor(
+            coordinator=coordinator,
+            device=mock_sprinkler_device_with_next_start_time,
+            description=description,
         )
 
         # Value should parse to a datetime
@@ -689,34 +707,35 @@ class TestBHyveZoneSensor:
         assert sensor.native_value.month == 5
         assert sensor.native_value.day == 1
 
-        # Programs attribute should reflect next_start_programs
+        # Programs attribute should be present when next_start_programs exists
         attrs = sensor.extra_state_attributes
         assert attrs["programs"] == ["e"]
 
     async def test_next_watering_sensor_no_schedule(
         self,
-        mock_sprinkler_device_with_battery: BHyveDevice,
+        mock_sprinkler_device_no_schedule: BHyveDevice,
     ) -> None:
         """Test next watering sensor returns None when next_start_time is absent."""
         coordinator = create_mock_coordinator(
             {
                 "test-device-123": {
-                    "device": mock_sprinkler_device_with_battery,
+                    "device": mock_sprinkler_device_no_schedule,
                     "history": [],
                     "landscapes": {},
                 }
             }
         )
 
-        zone = {"station": "1", "name": "Front Lawn"}
-        sensor = BHyveZoneSensor(
+        description = create_sensor_description(
+            mock_sprinkler_device_no_schedule, SENSOR_TYPES_SPRINKLER[1]
+        )
+        sensor = BHyveSensor(
             coordinator=coordinator,
-            device=mock_sprinkler_device_with_battery,
-            zone=zone,
-            zone_name="Front Lawn",
-            description=SENSOR_TYPES_ZONE[0],
+            device=mock_sprinkler_device_no_schedule,
+            description=description,
         )
 
         # No next_start_time in status — should return None (HA renders as Unknown)
         assert sensor.native_value is None
-        assert sensor.extra_state_attributes["programs"] is None
+        # No programs attribute when there is no schedule
+        assert sensor.extra_state_attributes == {}


### PR DESCRIPTION
Closes #410

Promotes the existing `next_start_time` valve attribute to a first-class per-zone `SensorDeviceClass.TIMESTAMP` sensor, as discussed in #410.

## What this adds

A `sensor.{zone_name}_next_watering` entity is created for each zone on a `sprinkler_timer` device. It reports the next scheduled watering time as a proper timestamp, enabling relative-time rendering ("in 14 hours"), long-term statistics, history graphs, and direct use in automations and dashboard cards without a template wrapper.

The existing `next_start_time` valve attribute is preserved for backward compatibility.

## Design decisions

- Per-zone scope, matching how `next_start_time` is already keyed in the data model
- Schedule-type-agnostic — reads whatever Orbit provides, no branching on program type
- `programs` extra state attribute exposes `next_start_programs` for visibility into which schedule is responsible
- Disabled by default (`entity_registry_enabled_default=False`) to avoid cluttering the UI on install — users opt in per zone. Happy to discuss if you prefer enabled by default.
- Reuses existing coordinator data and `orbit_time_to_local_time` helper — no new API calls

## Testing

- Tested against a 6-zone Timer on HA 
- Unit tests added covering populated, null, and missing `next_start_time` cases
- `ruff check` clean
- All 14 sensor tests passing