### PR TITLE
Fix adding/removing devices in config

### DIFF
--- a/custom_components/bhyve/__init__.py
+++ b/custom_components/bhyve/__init__.py
@@ -93,6 +93,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady(err) from err
     devices = filter_configured_devices(entry, all_devices)
 
+    # Remove any leaf devices that are no longer selected in options from the
+    # device registry. OptionsFlowWithReload triggers a reload after options
+    # change, so this runs on every setup and cleans up de-selected devices.
+    configured_ids = set(entry.options.get(CONF_DEVICES, []))
+    leaf_device_ids = {
+        str(d["id"]) for d in all_devices if d.get("type") != DEVICE_BRIDGE
+    }
+    if removed_device_ids := leaf_device_ids - configured_ids:
+        await remove_devices_from_registry(hass, removed_device_ids)
+
     # Build a mapping from device_gateway_topic to bridge device ID
     # so child devices can reference their bridge via via_device.
     # Bridges are always included by filter_configured_devices.
@@ -112,7 +122,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    entry.async_on_unload(entry.add_update_listener(update_listener))
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, client.stop)
 
@@ -134,33 +143,6 @@ async def remove_devices_from_registry(
                 device_registry.async_remove_device(device.id)
             except HomeAssistantError:
                 _LOGGER.exception("Failed to remove device %s from registry", device_id)
-
-
-async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload to update options and remove filtered devices."""
-    # Get the current client and all devices before reload
-    data = hass.data[DOMAIN].get(entry.entry_id)
-    if data:
-        client = data["client"]
-        try:
-            all_devices = await client.devices
-            # Get currently configured device IDs
-            configured_ids = set(entry.options.get(CONF_DEVICES, []))
-
-            # Find leaf devices that were removed from configuration
-            # (bridges are always included and not user-selectable)
-            leaf_device_ids = {
-                str(d["id"]) for d in all_devices if d.get("type") != DEVICE_BRIDGE
-            }
-            removed_device_ids = leaf_device_ids - configured_ids
-
-            if removed_device_ids:
-                # Remove devices from Home Assistant
-                await remove_devices_from_registry(hass, removed_device_ids)
-        except (BHyveError, KeyError, TimeoutError) as err:
-            _LOGGER.warning("Error checking for removed devices: %s", err)
-
-    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/tests/test_device_removal.py
+++ b/tests/test_device_removal.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from typing import TYPE_CHECKING
 
 import pytest
 from homeassistant.helpers import device_registry as dr
@@ -12,10 +11,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
-from custom_components.bhyve import (
-    remove_devices_from_registry,
-    update_listener,
-)
+from custom_components.bhyve import remove_devices_from_registry
 from custom_components.bhyve.const import CONF_DEVICES, DOMAIN
 from custom_components.bhyve.util import filter_configured_devices
 
@@ -65,169 +61,6 @@ async def test_remove_devices_from_registry(hass: HomeAssistant) -> None:
     assert device_registry.async_get(device1.id) is None
     assert device_registry.async_get(device2.id) is not None
     assert device_registry.async_get(device3.id) is None
-
-
-@pytest.mark.asyncio
-async def test_update_listener_removes_filtered_devices(hass: HomeAssistant) -> None:
-    """Test that update_listener removes devices filtered out in options."""
-    # Create a real config entry first
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        title="Test",
-        data={},
-        options={CONF_DEVICES: ["device2"]},  # Only device2 is configured
-        entry_id="test_entry",
-    )
-    config_entry.add_to_hass(hass)
-
-    # Create mock client with all devices
-    mock_client = MagicMock()
-
-    # Mock the async property behavior - each access returns a new coroutine
-    async def mock_devices() -> list[dict[str, Any]]:
-        return [
-            {"id": "device1", "name": "Device 1"},
-            {"id": "device2", "name": "Device 2"},
-            {"id": "device3", "name": "Device 3"},
-        ]
-
-    # Use PropertyMock to return a new coroutine each time the property is accessed
-    type(mock_client).devices = PropertyMock(side_effect=mock_devices)
-    # Setup mock data in hass
-    hass.data[DOMAIN] = {
-        "test_entry": {
-            "client": mock_client,
-        }
-    }
-
-    # Create device registry and add devices
-    device_registry = dr.async_get(hass)
-    device1 = device_registry.async_get_or_create(
-        config_entry_id="test_entry",
-        identifiers={(DOMAIN, "device1")},
-        name="Device 1",
-    )
-    device2 = device_registry.async_get_or_create(
-        config_entry_id="test_entry",
-        identifiers={(DOMAIN, "device2")},
-        name="Device 2",
-    )
-    device3 = device_registry.async_get_or_create(
-        config_entry_id="test_entry",
-        identifiers={(DOMAIN, "device3")},
-        name="Device 3",
-    )
-
-    # Mock the reload function
-    with patch.object(hass.config_entries, "async_reload", AsyncMock()) as mock_reload:
-        # Call update_listener
-        await update_listener(hass, config_entry)
-
-        # Verify that device1 and device3 are removed, device2 remains
-        assert device_registry.async_get(device1.id) is None
-        assert device_registry.async_get(device2.id) is not None
-        assert device_registry.async_get(device3.id) is None
-
-        # Verify reload was called
-        mock_reload.assert_called_once_with("test_entry")
-
-
-@pytest.mark.asyncio
-async def test_update_listener_handles_errors_gracefully(hass: HomeAssistant) -> None:
-    """Test that update_listener handles errors gracefully."""
-    # Create a real config entry
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        title="Test",
-        data={},
-        options={CONF_DEVICES: ["device1"]},
-        entry_id="test_entry",
-    )
-    config_entry.add_to_hass(hass)
-
-    # Create mock client that raises an error
-    mock_client = MagicMock()
-
-    # Mock the async property to raise an error
-    async def mock_devices_error() -> None:
-        msg = "API Error"
-        raise KeyError(msg)
-
-    # Use PropertyMock to return a new coroutine each time
-    type(mock_client).devices = PropertyMock(side_effect=mock_devices_error)
-
-    # Setup mock data in hass
-    hass.data[DOMAIN] = {
-        "test_entry": {
-            "client": mock_client,
-        }
-    }
-
-    # Mock the reload function
-    with patch.object(hass.config_entries, "async_reload", AsyncMock()) as mock_reload:
-        # Call update_listener - should not raise exception
-        await update_listener(hass, config_entry)
-
-        # Verify reload was still called despite error
-        mock_reload.assert_called_once_with("test_entry")
-
-
-@pytest.mark.asyncio
-async def test_device_recreation_after_filtering_back_in(hass: HomeAssistant) -> None:
-    """Test that devices are properly recreated when filtered back into options."""
-    # Create a real config entry with initially no devices configured
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        title="Test",
-        data={},
-        options={CONF_DEVICES: []},  # Start with no devices configured
-        entry_id="test_entry",
-    )
-    config_entry.add_to_hass(hass)
-
-    # Create mock client with all devices
-    mock_client = MagicMock()
-
-    # Mock the async property behavior - each access returns a new coroutine
-    async def mock_devices() -> list[dict[str, Any]]:
-        return [
-            {"id": "device1", "name": "Device 1"},
-            {"id": "device2", "name": "Device 2"},
-        ]
-
-    # Use PropertyMock to return a new coroutine each time the property is accessed
-    type(mock_client).devices = PropertyMock(side_effect=mock_devices)
-    # Setup mock data in hass
-    hass.data[DOMAIN] = {
-        "test_entry": {
-            "client": mock_client,
-        }
-    }
-
-    # Create device registry
-    device_registry = dr.async_get(hass)
-
-    # Initially no devices should be in registry since none are configured
-    initial_devices = [
-        d for d in device_registry.devices.values() if d.config_entry_id == "test_entry"
-    ]
-    assert len(initial_devices) == 0
-
-    # Now create a new config entry with device1 included to simulate options update
-    config_entry_updated = MockConfigEntry(
-        domain=DOMAIN,
-        title="Test",
-        data={},
-        options={CONF_DEVICES: ["device1"]},  # Now device1 is configured
-        entry_id="test_entry",
-    )
-
-    # Mock the reload function and call update_listener
-    with patch.object(hass.config_entries, "async_reload", AsyncMock()) as mock_reload:
-        await update_listener(hass, config_entry_updated)
-
-        # Verify reload was called
-        mock_reload.assert_called_once_with("test_entry")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- HA 2025.8+ raises `ValueError: Config entry update listeners should not be used with OptionsFlowWithReload` when submitting the options flow, breaking the "add a new device" path.
- Removes the redundant `add_update_listener` registration; `OptionsFlowWithReload` already reloads the entry automatically.
- Moves the de-selected-device registry cleanup into `async_setup_entry` so the same behavior runs on the auto-reload.

Fixes #411

## Test plan
- [x] `./scripts/lint` — clean
- [x] `pytest tests/` — 152 passed, 5 skipped
- [x] Manual: add a new B-hyve device via Settings → Integrations → Orbit B-hyve → Configure → submit; confirm no `ValueError` and the new device appears
- [x] Manual: de-select an existing device via the options flow; confirm it is removed from the device registry after the auto-reload