### PR TITLE
Back off Orbit websocket reconnects

### DIFF
--- a/custom_components/bhyve/pybhyve/websocket.py
+++ b/custom_components/bhyve/pybhyve/websocket.py
@@ -17,6 +17,7 @@ STATE_RUNNING = "running"
 STATE_STOPPED = "stopped"
 
 RECONNECT_DELAY = 5
+MAX_RECONNECT_DELAY = 300
 
 
 # pylint: disable=too-many-instance-attributes
@@ -48,6 +49,7 @@ class OrbitWebsocket:
         self._heartbeat: int = 25
         self._ws: ClientWebSocketResponse | None = None
         self._closing: bool = False
+        self._reconnect_delay: int = RECONNECT_DELAY
 
     def _cancel_heartbeat(self) -> None:
         if self._heartbeat_cb is not None:
@@ -111,6 +113,7 @@ class OrbitWebsocket:
                     _LOGGER.info("Websocket connected")
 
                     self._reset_heartbeat()
+                    self._reconnect_delay = RECONNECT_DELAY
 
                     self.state = STATE_RUNNING
 
@@ -173,8 +176,19 @@ class OrbitWebsocket:
                         )
                         self.state = STATE_STOPPED
 
+        except aiohttp.ClientResponseError as err:
+            if err.status in (500, 502, 503, 504):
+                _LOGGER.warning(
+                    "Orbit websocket endpoint returned HTTP %s; retrying with backoff",
+                    err.status,
+                )
+            else:
+                _LOGGER.error("Unexpected websocket HTTP error %s", err)  # noqa: TRY400
+            self.state = STATE_STOPPED
+            self.retry()
+
         except aiohttp.ClientConnectorError:
-            _LOGGER.error("Client connection error; state: %s", self.state)  # noqa: TRY400
+            _LOGGER.warning("Client connection error; state: %s", self.state)
             self.state = STATE_STOPPED
             self.retry()
 
@@ -204,10 +218,16 @@ class OrbitWebsocket:
         """Retry to connect to Orbit."""
         if self.state != STATE_STARTING:
             _LOGGER.info(
-                "Reconnecting to Orbit in %i; state: %s", RECONNECT_DELAY, self.state
+                "Reconnecting to Orbit in %i; state: %s",
+                self._reconnect_delay,
+                self.state,
             )
             self.state = STATE_STARTING
-            self._loop.call_later(RECONNECT_DELAY, self.start)
+            self._loop.call_later(self._reconnect_delay, self.start)
+            self._reconnect_delay = min(
+                self._reconnect_delay * 2,
+                MAX_RECONNECT_DELAY,
+            )
         else:
             _LOGGER.info("Ignoring websocket retry; state: %s", self.state)
 

--- a/custom_components/bhyve/pybhyve/websocket.py
+++ b/custom_components/bhyve/pybhyve/websocket.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from asyncio import AbstractEventLoop, ensure_future
+from asyncio import AbstractEventLoop, TimerHandle, ensure_future
 from collections.abc import Callable
 from math import ceil
 from typing import Any
@@ -50,11 +50,17 @@ class OrbitWebsocket:
         self._ws: ClientWebSocketResponse | None = None
         self._closing: bool = False
         self._reconnect_delay: int = RECONNECT_DELAY
+        self._reconnect_cb: TimerHandle | None = None
 
     def _cancel_heartbeat(self) -> None:
         if self._heartbeat_cb is not None:
             self._heartbeat_cb.cancel()
             self._heartbeat_cb = None
+
+    def _cancel_reconnect(self) -> None:
+        if self._reconnect_cb is not None:
+            self._reconnect_cb.cancel()
+            self._reconnect_cb = None
 
     def _reset_heartbeat(self) -> None:
         self._cancel_heartbeat()
@@ -90,6 +96,11 @@ class OrbitWebsocket:
 
     def start(self) -> None:
         """Start the websocket."""
+        self._cancel_reconnect()
+        if self._closing:
+            _LOGGER.info("Websocket closed intentionally, not starting")
+            return
+
         if self.state != STATE_RUNNING:
             self.state = STATE_STARTING
         self._loop.create_task(self.running())
@@ -211,11 +222,16 @@ class OrbitWebsocket:
         self._closing = True
         self.state = STATE_STOPPED
         self._cancel_heartbeat()
+        self._cancel_reconnect()
         if self._ws is not None:
             await self._ws.close()
 
     def retry(self) -> None:
         """Retry to connect to Orbit."""
+        if self._closing:
+            _LOGGER.info("Websocket closed intentionally, not scheduling reconnect")
+            return
+
         if self.state != STATE_STARTING:
             _LOGGER.info(
                 "Reconnecting to Orbit in %i; state: %s",
@@ -223,7 +239,9 @@ class OrbitWebsocket:
                 self.state,
             )
             self.state = STATE_STARTING
-            self._loop.call_later(self._reconnect_delay, self.start)
+            self._reconnect_cb = self._loop.call_later(
+                self._reconnect_delay, self.start
+            )
             self._reconnect_delay = min(
                 self._reconnect_delay * 2,
                 MAX_RECONNECT_DELAY,

--- a/custom_components/bhyve/pybhyve/websocket.py
+++ b/custom_components/bhyve/pybhyve/websocket.py
@@ -50,6 +50,7 @@ class OrbitWebsocket:
         self._ws: ClientWebSocketResponse | None = None
         self._closing: bool = False
         self._reconnect_delay: int = RECONNECT_DELAY
+        # Keep the delayed retry handle so an integration unload can cancel it.
         self._reconnect_cb: TimerHandle | None = None
 
     def _cancel_heartbeat(self) -> None:
@@ -124,6 +125,7 @@ class OrbitWebsocket:
                     _LOGGER.info("Websocket connected")
 
                     self._reset_heartbeat()
+                    # The endpoint recovered; future disconnects should retry quickly.
                     self._reconnect_delay = RECONNECT_DELAY
 
                     self.state = STATE_RUNNING
@@ -239,6 +241,7 @@ class OrbitWebsocket:
                 self.state,
             )
             self.state = STATE_STARTING
+            # Track the delayed start so stop() can prevent stale reconnects.
             self._reconnect_cb = self._loop.call_later(
                 self._reconnect_delay, self.start
             )

--- a/custom_components/bhyve/pybhyve/websocket.py
+++ b/custom_components/bhyve/pybhyve/websocket.py
@@ -19,6 +19,9 @@ STATE_STOPPED = "stopped"
 RECONNECT_DELAY = 5
 MAX_RECONNECT_DELAY = 300
 
+HTTP_SERVER_ERROR_MIN = 500
+HTTP_SERVER_ERROR_MAX = 600
+
 
 # pylint: disable=too-many-instance-attributes
 class OrbitWebsocket:
@@ -190,7 +193,7 @@ class OrbitWebsocket:
                         self.state = STATE_STOPPED
 
         except aiohttp.ClientResponseError as err:
-            if err.status in (500, 502, 503, 504):
+            if HTTP_SERVER_ERROR_MIN <= err.status < HTTP_SERVER_ERROR_MAX:
                 _LOGGER.warning(
                     "Orbit websocket endpoint returned HTTP %s; retrying with backoff",
                     err.status,

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,11 +1,14 @@
 """Test Orbit BHyve websocket transport."""
 
 import json
+import logging
 from collections.abc import Callable, Coroutine
 from types import TracebackType
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
+import aiohttp
+import pytest
 from aiohttp import WSMsgType
 
 from custom_components.bhyve.pybhyve.websocket import (
@@ -14,6 +17,8 @@ from custom_components.bhyve.pybhyve.websocket import (
     STATE_STOPPED,
     OrbitWebsocket,
 )
+
+WEBSOCKET_LOGGER = "custom_components.bhyve.pybhyve.websocket"
 
 
 class FakeTimerHandle:
@@ -116,16 +121,49 @@ class FakeWebsocketContext:
         self.websocket.closed = True
 
 
+class FailingWebsocketContext:
+    """Fake websocket context that raises on entry."""
+
+    def __init__(self, exc: BaseException) -> None:
+        """Initialize the failing context with the exception to raise."""
+        self.exc = exc
+
+    async def __aenter__(self) -> FakeWebSocket:
+        """Raise the configured exception."""
+        raise self.exc
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Exit the failing context (unreachable when __aenter__ raises)."""
+
+
 class FakeSession:
     """Fake aiohttp client session."""
 
-    def __init__(self) -> None:
-        """Initialize the fake session."""
+    def __init__(self, ws_connect_error: BaseException | None = None) -> None:
+        """Initialize the fake session, optionally raising on ws_connect."""
         self.websocket = FakeWebSocket()
+        self.ws_connect_error = ws_connect_error
 
-    def ws_connect(self, _url: str) -> FakeWebsocketContext:
-        """Return a fake websocket context."""
+    def ws_connect(self, _url: str) -> FakeWebsocketContext | FailingWebsocketContext:
+        """Return a fake websocket context, or one that raises on entry."""
+        if self.ws_connect_error is not None:
+            return FailingWebsocketContext(self.ws_connect_error)
         return FakeWebsocketContext(self.websocket)
+
+
+def make_response_error(status: int) -> aiohttp.ClientResponseError:
+    """Build an aiohttp ClientResponseError with the given status."""
+    return aiohttp.ClientResponseError(
+        request_info=MagicMock(),
+        history=(),
+        status=status,
+        message=f"HTTP {status}",
+    )
 
 
 def create_websocket(
@@ -202,3 +240,44 @@ async def test_stale_reconnect_callback_does_not_restart_after_stop() -> None:
 
     assert websocket.state == STATE_STOPPED
     assert not loop.created_tasks
+
+
+@pytest.mark.parametrize("status", [500, 502, 503, 504, 599])
+async def test_5xx_handshake_warns_and_schedules_retry(
+    caplog: pytest.LogCaptureFixture, status: int
+) -> None:
+    """Test 5xx handshake responses warn and schedule a backoff retry."""
+    loop = FakeLoop()
+    session = FakeSession(ws_connect_error=make_response_error(status))
+    websocket = create_websocket(loop=loop, session=session)
+
+    caplog.set_level(logging.DEBUG, logger=WEBSOCKET_LOGGER)
+    await websocket.running()
+
+    records = [r for r in caplog.records if r.name == WEBSOCKET_LOGGER]
+    assert any(
+        r.levelno == logging.WARNING and str(status) in r.getMessage() for r in records
+    )
+    assert not any(r.levelno >= logging.ERROR for r in records)
+    assert loop.call_later_handles[-1].delay == RECONNECT_DELAY
+    assert websocket._reconnect_delay == RECONNECT_DELAY * 2
+
+
+async def test_non_5xx_handshake_errors_and_schedules_retry(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test non-5xx handshake responses log an error and schedule a retry."""
+    loop = FakeLoop()
+    session = FakeSession(ws_connect_error=make_response_error(401))
+    websocket = create_websocket(loop=loop, session=session)
+
+    caplog.set_level(logging.DEBUG, logger=WEBSOCKET_LOGGER)
+    await websocket.running()
+
+    records = [r for r in caplog.records if r.name == WEBSOCKET_LOGGER]
+    assert any(
+        r.levelno == logging.ERROR
+        and "Unexpected websocket HTTP error" in r.getMessage()
+        for r in records
+    )
+    assert loop.call_later_handles[-1].delay == RECONNECT_DELAY

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,0 +1,204 @@
+"""Test Orbit BHyve websocket transport."""
+
+import json
+from collections.abc import Callable, Coroutine
+from types import TracebackType
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from aiohttp import WSMsgType
+
+from custom_components.bhyve.pybhyve.websocket import (
+    MAX_RECONNECT_DELAY,
+    RECONNECT_DELAY,
+    STATE_STOPPED,
+    OrbitWebsocket,
+)
+
+
+class FakeTimerHandle:
+    """Fake asyncio timer handle."""
+
+    def __init__(self, delay: float, callback: Callable[[], None]) -> None:
+        """Initialize the fake timer handle."""
+        self.delay = delay
+        self.callback = callback
+        self.cancelled = False
+
+    def cancel(self) -> None:
+        """Cancel the fake timer handle."""
+        self.cancelled = True
+
+
+class FakeLoop:
+    """Fake event loop for websocket scheduling tests."""
+
+    def __init__(self) -> None:
+        """Initialize the fake loop."""
+        self.call_later_handles: list[FakeTimerHandle] = []
+        self.call_at_handles: list[FakeTimerHandle] = []
+        self.created_tasks: list[Coroutine[Any, Any, Any]] = []
+
+    def time(self) -> float:
+        """Return the fake loop time."""
+        return 0
+
+    def call_at(self, when: float, callback: Callable[[], None]) -> FakeTimerHandle:
+        """Record a scheduled call_at callback."""
+        handle = FakeTimerHandle(when, callback)
+        self.call_at_handles.append(handle)
+        return handle
+
+    def call_later(self, delay: float, callback: Callable[[], None]) -> FakeTimerHandle:
+        """Record a scheduled call_later callback."""
+        handle = FakeTimerHandle(delay, callback)
+        self.call_later_handles.append(handle)
+        return handle
+
+    def create_task(self, coro: Coroutine[Any, Any, Any]) -> MagicMock:
+        """Record and close a created coroutine task."""
+        self.created_tasks.append(coro)
+        coro.close()
+        return MagicMock()
+
+
+class FakeMessage:
+    """Fake websocket message."""
+
+    type = WSMsgType.CLOSE
+
+
+class FakeWebSocket:
+    """Fake aiohttp websocket response."""
+
+    def __init__(self) -> None:
+        """Initialize the fake websocket response."""
+        self.closed = False
+        self.sent: list[str] = []
+
+    async def send_str(self, data: str) -> None:
+        """Record sent websocket data."""
+        self.sent.append(data)
+
+    async def receive(self) -> FakeMessage:
+        """Return a close message to end the receive loop."""
+        return FakeMessage()
+
+    async def pong(self) -> None:
+        """Handle websocket pong calls."""
+
+    async def close(self) -> None:
+        """Close the fake websocket."""
+        self.closed = True
+
+    def exception(self) -> None:
+        """Return no websocket exception."""
+
+
+class FakeWebsocketContext:
+    """Fake websocket async context manager."""
+
+    def __init__(self, websocket: FakeWebSocket) -> None:
+        """Initialize the fake websocket context."""
+        self.websocket = websocket
+
+    async def __aenter__(self) -> FakeWebSocket:
+        """Enter the fake websocket context."""
+        return self.websocket
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Exit the fake websocket context."""
+        self.websocket.closed = True
+
+
+class FakeSession:
+    """Fake aiohttp client session."""
+
+    def __init__(self) -> None:
+        """Initialize the fake session."""
+        self.websocket = FakeWebSocket()
+
+    def ws_connect(self, _url: str) -> FakeWebsocketContext:
+        """Return a fake websocket context."""
+        return FakeWebsocketContext(self.websocket)
+
+
+def create_websocket(
+    loop: FakeLoop | None = None,
+    session: FakeSession | None = None,
+) -> OrbitWebsocket:
+    """Create an Orbit websocket with test doubles."""
+    return OrbitWebsocket(
+        token="token",
+        loop=loop or FakeLoop(),
+        session=session or FakeSession(),
+        url="wss://example.test",
+        async_callback=AsyncMock(),
+    )
+
+
+def test_retry_uses_exponential_backoff_until_max() -> None:
+    """Test reconnect retries back off to the maximum delay."""
+    loop = FakeLoop()
+    websocket = create_websocket(loop=loop)
+
+    for expected_delay in [5, 10, 20, 40, 80, 160, 300, 300]:
+        websocket.state = STATE_STOPPED
+
+        websocket.retry()
+
+        handle = loop.call_later_handles[-1]
+        assert handle.delay == expected_delay
+        handle.callback()
+
+    assert websocket._reconnect_delay == MAX_RECONNECT_DELAY
+
+
+async def test_successful_connection_resets_reconnect_delay() -> None:
+    """Test a successful websocket connection resets the backoff delay."""
+    loop = FakeLoop()
+    session = FakeSession()
+    websocket = create_websocket(loop=loop, session=session)
+    websocket._reconnect_delay = 80
+
+    await websocket.running()
+
+    assert loop.call_later_handles[-1].delay == RECONNECT_DELAY
+    assert websocket._reconnect_delay == RECONNECT_DELAY * 2
+    assert json.loads(session.websocket.sent[0]) == {
+        "event": "app_connection",
+        "orbit_session_token": "token",
+    }
+
+
+async def test_stop_cancels_pending_reconnect() -> None:
+    """Test stop cancels a pending reconnect timer."""
+    loop = FakeLoop()
+    websocket = create_websocket(loop=loop)
+
+    websocket.retry()
+    handle = loop.call_later_handles[-1]
+
+    await websocket.stop()
+
+    assert handle.cancelled
+    assert websocket._reconnect_cb is None
+
+
+async def test_stale_reconnect_callback_does_not_restart_after_stop() -> None:
+    """Test a stale reconnect callback cannot restart a stopped websocket."""
+    loop = FakeLoop()
+    websocket = create_websocket(loop=loop)
+
+    websocket.retry()
+    handle = loop.call_later_handles[-1]
+    await websocket.stop()
+    handle.callback()
+
+    assert websocket.state == STATE_STOPPED
+    assert not loop.created_tasks


### PR DESCRIPTION
## Summary
- add exponential backoff for Orbit websocket reconnect attempts, capped at 5 minutes
- handle transient websocket handshake HTTP 5xx responses as warnings instead of generic errors
- reset the retry delay after a successful websocket connection

## Why
When the Orbit websocket endpoint returns transient 5xx responses, the integration retries every 5 seconds and can flood Home Assistant logs while the upstream endpoint is unhealthy. The integration should keep retrying, but progressively slow repeated attempts until the endpoint recovers.

Related: #190

## Validation
- `python3 -m py_compile custom_components/bhyve/pybhyve/websocket.py`
- `ruff check custom_components/bhyve/pybhyve/websocket.py`
- `ruff format --check custom_components/bhyve/pybhyve/websocket.py`
- `python -m pytest tests/test_client.py -q` (`7 passed`)
- Applied the same patch to a Home Assistant `2026.4.4` instance, restarted Core, and confirmed the repeated 5-second Orbit websocket `502` log loop stopped after restart.
