### PR TITLE
Fix login and websocket auth after Orbit API change

### DIFF
--- a/custom_components/bhyve/pybhyve/client.py
+++ b/custom_components/bhyve/pybhyve/client.py
@@ -18,6 +18,7 @@ from .const import (
     LANDSCAPE_DESCRIPTIONS_PATH,
     LOGIN_PATH,
     TIMER_PROGRAMS_PATH,
+    WEB_HOST,
     WS_HOST,
 )
 from .errors import AuthenticationError, BHyveError, RequestError
@@ -25,6 +26,11 @@ from .typings import BHyveDevice, BHyveTimerProgram, BHyveZoneLandscape
 from .websocket import OrbitWebsocket
 
 _LOGGER = logging.getLogger(__name__)
+
+_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36"
+)
 
 
 class BHyveClient:
@@ -70,13 +76,13 @@ class BHyveClient:
             "Accept": "application/json, text/plain, */*",
             "Host": re.sub("https?://", "", API_HOST),
             "Content-Type": "application/json; charset=utf-8;",
-            "Referer": API_HOST,
+            "Origin": WEB_HOST,
+            "Referer": f"{WEB_HOST}/",
+            "User-Agent": _USER_AGENT,
+            "orbit-app-id": "Bhyve Dashboard",
+            "orbit-api-key": self._token or "null",
             "Orbit-Session-Token": self._token or "",
         }
-        headers["User-Agent"] = (
-            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
-            "Chrome/72.0.3626.81 Safari/537.36"
-        )
 
         try:
             async with self._session.request(
@@ -183,14 +189,24 @@ class BHyveClient:
         """Log in with username & password and save the token."""
         url: str = f"{API_HOST}{LOGIN_PATH}"
         json = {"session": {"email": self._username, "password": self._password}}
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json; charset=UTF-8",
+            "Origin": WEB_HOST,
+            "Referer": f"{WEB_HOST}/",
+            "User-Agent": _USER_AGENT,
+            "orbit-app-id": "Bhyve Dashboard",
+            "orbit-api-key": "null",
+        }
 
         try:
-            async with self._session.request("post", url, json=json) as resp:
+            async with self._session.request(
+                "post", url, json=json, headers=headers
+            ) as resp:
                 try:
                     resp.raise_for_status()
                     response = await resp.json(content_type=None)
-                    _LOGGER.debug("Logged in")
-                    self._token = response["orbit_session_token"]
+                    self._token = response["orbit_api_key"]
 
                 except ClientResponseError as response_err:
                     if response_err.status in (401, 403):

--- a/custom_components/bhyve/pybhyve/const.py
+++ b/custom_components/bhyve/pybhyve/const.py
@@ -1,6 +1,7 @@
 """Define constants for the BHyve component."""
 
 API_HOST = "https://api.orbitbhyve.com"
+WEB_HOST = "https://techsupport.orbitbhyve.com"
 WS_HOST = "wss://api.orbitbhyve.com/v1/events"
 
 LOGIN_PATH = "/v1/session"

--- a/custom_components/bhyve/pybhyve/websocket.py
+++ b/custom_components/bhyve/pybhyve/websocket.py
@@ -10,7 +10,14 @@ from typing import Any
 import aiohttp
 from aiohttp import ClientWebSocketResponse, WSMsgType
 
+from .const import WEB_HOST
+
 _LOGGER = logging.getLogger(__name__)
+
+_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36"
+)
 
 STATE_STARTING = "starting"
 STATE_RUNNING = "running"
@@ -114,7 +121,11 @@ class OrbitWebsocket:
         background_tasks = set()
         try:
             if self._ws is None or self._ws.closed or self.state != STATE_RUNNING:
-                async with self._session.ws_connect(self._url) as self._ws:
+                async with self._session.ws_connect(
+                    self._url,
+                    origin=WEB_HOST,
+                    headers={"User-Agent": _USER_AGENT},
+                ) as self._ws:
                     _LOGGER.info("Authenticating websocket")
                     await self._ws.send_str(
                         json.dumps(

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -149,7 +149,11 @@ class FakeSession:
         self.websocket = FakeWebSocket()
         self.ws_connect_error = ws_connect_error
 
-    def ws_connect(self, _url: str) -> FakeWebsocketContext | FailingWebsocketContext:
+    def ws_connect(
+        self,
+        _url: str,
+        **_kwargs: object,
+    ) -> FakeWebsocketContext | FailingWebsocketContext:
         """Return a fake websocket context, or one that raises on entry."""
         if self.ws_connect_error is not None:
             return FailingWebsocketContext(self.ws_connect_error)


### PR DESCRIPTION
## Summary
- Orbit's API now gates `/v1/session` on browser-style headers — added `orbit-app-id`, `orbit-api-key`, `Origin`, `Referer`, and a modern Chrome `User-Agent` to the login and authenticated request paths.
- Login response field renamed from `orbit_session_token` to `orbit_api_key`; updated the token assignment accordingly.
- Websocket upgrade was returning HTTP 403 — set `Origin: https://techsupport.orbitbhyve.com` and a browser `User-Agent` on `ws_connect` to match the dashboard handshake.
- Added `WEB_HOST` constant for the techsupport dashboard origin.

Fixes #427
