### PR TITLE
4.1.1

### DIFF
--- a/custom_components/bhyve/manifest.json
+++ b/custom_components/bhyve/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/sebr/bhyve-home-assistant/issues",
-  "version": "4.1.0"
+  "version": "4.1.1"
 }


### PR DESCRIPTION
## Summary
- Patch release bumping `manifest.json` to 4.1.1.
- Picks up #428 — fix login and websocket auth after Orbit API change (closes #427).

## Test plan
- [x] Already validated via #428 (lint + tests pass).
- [ ] After merge: trigger the **Release** workflow via `workflow_dispatch` to tag 4.1.1 and publish the GitHub release.