### PR TITLE
Fix smart watering toggle using device water_sense_mode (#434)

### DIFF
--- a/custom_components/bhyve/coordinator.py
+++ b/custom_components/bhyve/coordinator.py
@@ -315,16 +315,19 @@ class BHyveDataUpdateCoordinator(DataUpdateCoordinator):
         # Notify all listening entities
         self.async_set_updated_data(self.data)
 
-    def _set_zones_smart_watering(
+    def _set_device_smart_watering(
         self, device_id: str | None, *, enabled: bool
     ) -> None:
-        """Update smart_watering_enabled on all zones of a device."""
+        """Mirror smart watering state onto device water_sense_mode and zones."""
         if not device_id:
             return
         device_data = self.data.get("devices", {}).get(device_id, {})
         device = device_data.get("device", {})
+        if "water_sense_mode" in device:
+            device["water_sense_mode"] = "auto" if enabled else "off"
         for zone in device.get("zones", []):
-            zone["smart_watering_enabled"] = enabled
+            if "smart_watering_enabled" in zone:
+                zone["smart_watering_enabled"] = enabled
 
     @staticmethod
     def _get_program_id(event_data: dict[str, Any]) -> str | None:
@@ -357,7 +360,7 @@ class BHyveDataUpdateCoordinator(DataUpdateCoordinator):
                 if program_data.get("is_smart_program"):
                     # Smart program created means smart watering was enabled
                     device_id = event_data.get("device_id")
-                    self._set_zones_smart_watering(device_id, enabled=True)
+                    self._set_device_smart_watering(device_id, enabled=True)
                 else:
                     self.hass.bus.async_fire(
                         "bhyve_program_created",
@@ -383,9 +386,9 @@ class BHyveDataUpdateCoordinator(DataUpdateCoordinator):
                 return
             if is_smart:
                 # Smart program destroy means smart watering was disabled.
-                # Update zone data so smart watering switches reflect the change.
+                # Update device data so the smart watering switch reflects it.
                 device_id = event_data.get("device_id")
-                self._set_zones_smart_watering(device_id, enabled=False)
+                self._set_device_smart_watering(device_id, enabled=False)
                 # Fall through to update the program data
 
         # For update events, check if program exists

--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -167,7 +167,10 @@ async def async_setup_entry(
                 )
             )
 
-            # Create smart watering switches for zones that support it
+            # Smart watering is a device-level toggle (`water_sense_mode`), but
+            # it's exposed per-zone as a "smart water program". Keep per-zone
+            # entities for backward compatibility; each one reflects and
+            # controls the device-level master toggle.
             smart_watering_desc = BHyveSwitchEntityDescription(
                 key="smart_watering",
                 translation_key="smart_watering",
@@ -369,7 +372,7 @@ class BHyveProgramSwitch(BHyveCoordinatorEntity, SwitchEntity):
 
 
 class BHyveSmartWateringSwitch(BHyveCoordinatorEntity, SwitchEntity):
-    """Define a BHyve smart watering switch for a zone."""
+    """Per-zone smart watering switch backed by device water_sense_mode."""
 
     entity_description: BHyveSwitchEntityDescription
     _attr_has_entity_name = True
@@ -394,32 +397,25 @@ class BHyveSmartWateringSwitch(BHyveCoordinatorEntity, SwitchEntity):
 
         super().__init__(coordinator, device)
 
+        self._device_type = device.get("type")
         self._attr_unique_id = (
             f"{self._mac_address}:{self._device_id}:{self._zone_id}:smart_watering"
         )
 
-    def _get_zone_data(self) -> dict:
-        """Get current zone data from coordinator."""
-        for zone in self.device_data.get("zones", []):
-            if zone.get("station") == self._zone_id:
-                return zone
-        return {}
-
     @property
     def is_on(self) -> bool:
-        """Return true if smart watering is enabled for this zone."""
-        return self._get_zone_data().get("smart_watering_enabled", False)
+        """Return true if smart watering is enabled at the device level."""
+        return self.device_data.get("water_sense_mode") == "auto"
 
     async def _set_smart_watering(self, *, enabled: bool) -> None:
-        """Update the zone's smart_watering_enabled on the device."""
-        zones = [
-            {**z, "smart_watering_enabled": enabled}
-            if z.get("station") == self._zone_id
-            else z
-            for z in self.device_data.get("zones", [])
-        ]
+        """Flip device water_sense_mode (smart watering is device-wide)."""
         await self.coordinator.client.update_device(
-            {"id": self._device_id, "zones": zones}
+            {
+                "id": self._device_id,
+                "type": self._device_type,
+                "mac_address": self._mac_address,
+                "water_sense_mode": "auto" if enabled else "off",
+            }
         )
 
     async def async_turn_on(self, **_kwargs: Any) -> None:

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1246,6 +1246,7 @@ class TestBHyveSmartWateringSwitch:
                 "firmware_version": "0085",
                 "is_connected": True,
                 "status": {"run_mode": "auto"},
+                "water_sense_mode": "auto",
                 "zones": [
                     {"station": 1, "smart_watering_enabled": True},
                 ],
@@ -1266,6 +1267,7 @@ class TestBHyveSmartWateringSwitch:
                 "firmware_version": "0087",
                 "is_connected": True,
                 "status": {"run_mode": "auto"},
+                "water_sense_mode": "auto",
                 "zones": [
                     {
                         "station": 1,
@@ -1280,7 +1282,7 @@ class TestBHyveSmartWateringSwitch:
                     {
                         "station": 3,
                         "name": "Side Garden",
-                        "smart_watering_enabled": False,
+                        "smart_watering_enabled": True,
                     },
                 ],
             }
@@ -1298,61 +1300,60 @@ class TestBHyveSmartWateringSwitch:
         assert "2:smart_watering" in switch_2.unique_id
         assert "3:smart_watering" in switch_3.unique_id
 
-    async def test_is_on_reads_zone_data(self) -> None:
-        """Test is_on reflects the zone's smart_watering_enabled value."""
-        device = BHyveDevice(
+    async def test_is_on_reads_device_water_sense_mode(self) -> None:
+        """is_on reflects the device-level water_sense_mode (not per-zone)."""
+        device_on = BHyveDevice(
             {
-                "id": "device-3",
-                "name": "Monash",
+                "id": "device-on",
+                "name": "On",
                 "type": "sprinkler_timer",
                 "mac_address": "aa:bb:cc:dd:ee:03",
                 "hardware_version": "WT25G2-0001",
                 "firmware_version": "0087",
                 "is_connected": True,
                 "status": {"run_mode": "auto"},
+                "water_sense_mode": "auto",
                 "zones": [
-                    {
-                        "station": 1,
-                        "name": "Front Lawn",
-                        "smart_watering_enabled": True,
-                    },
-                    {
-                        "station": 2,
-                        "name": "Back Lawn",
-                        "smart_watering_enabled": False,
-                    },
+                    {"station": 1, "smart_watering_enabled": True},
+                    {"station": 2, "smart_watering_enabled": True},
                 ],
             }
         )
-        coordinator = create_mock_coordinator(
+        device_off = BHyveDevice(
             {
-                "device-3": {
-                    "device": device,
-                    "history": [],
-                    "landscapes": {},
-                }
-            },
-            {},
-        )
-
-        switch_on = self._create_switch(device, device["zones"][0], coordinator)
-        switch_off = self._create_switch(device, device["zones"][1], coordinator)
-
-        assert switch_on.is_on is True
-        assert switch_off.is_on is False
-
-    async def test_turn_on_patches_zone(self) -> None:
-        """Test turning on sets smart_watering_enabled on the zone."""
-        device = BHyveDevice(
-            {
-                "id": "device-4",
-                "name": "Test",
+                "id": "device-off",
+                "name": "Off",
                 "type": "sprinkler_timer",
                 "mac_address": "aa:bb:cc:dd:ee:04",
+                "hardware_version": "WT25G2-0001",
+                "firmware_version": "0087",
+                "is_connected": True,
+                "status": {"run_mode": "auto"},
+                "water_sense_mode": "off",
+                "zones": [
+                    {"station": 1, "smart_watering_enabled": False},
+                    {"station": 2, "smart_watering_enabled": False},
+                ],
+            }
+        )
+
+        assert self._create_switch(device_on, device_on["zones"][0]).is_on is True
+        assert self._create_switch(device_on, device_on["zones"][1]).is_on is True
+        assert self._create_switch(device_off, device_off["zones"][0]).is_on is False
+
+    async def test_turn_on_sends_device_payload(self) -> None:
+        """Turn on PUTs id+type+mac_address+water_sense_mode=auto for the device."""
+        device = BHyveDevice(
+            {
+                "id": "device-5",
+                "name": "Test",
+                "type": "sprinkler_timer",
+                "mac_address": "aa:bb:cc:dd:ee:05",
                 "hardware_version": "HT25-0000",
                 "firmware_version": "0085",
                 "is_connected": True,
                 "status": {"run_mode": "auto"},
+                "water_sense_mode": "off",
                 "zones": [
                     {"station": 1, "smart_watering_enabled": False},
                     {"station": 2, "smart_watering_enabled": False},
@@ -1360,34 +1361,34 @@ class TestBHyveSmartWateringSwitch:
             }
         )
         coordinator = create_mock_coordinator(
-            {"device-4": {"device": device, "history": [], "landscapes": {}}},
+            {"device-5": {"device": device, "history": [], "landscapes": {}}},
             {},
         )
         switch = self._create_switch(device, device["zones"][0], coordinator)
 
         await switch.async_turn_on()
-        coordinator.client.update_device.assert_called_once()
-        call_args = coordinator.client.update_device.call_args[0][0]
-        assert call_args["id"] == "device-4"
-        # Zone 1 should be enabled, zone 2 unchanged
-        zones = call_args["zones"]
-        assert zones[0]["station"] == 1
-        assert zones[0]["smart_watering_enabled"] is True
-        assert zones[1]["station"] == 2
-        assert zones[1]["smart_watering_enabled"] is False
+        coordinator.client.update_device.assert_called_once_with(
+            {
+                "id": "device-5",
+                "type": "sprinkler_timer",
+                "mac_address": "aa:bb:cc:dd:ee:05",
+                "water_sense_mode": "auto",
+            }
+        )
 
-    async def test_turn_off_patches_zone(self) -> None:
-        """Test turning off sets smart_watering_enabled false on the zone."""
+    async def test_turn_off_sends_device_payload(self) -> None:
+        """Turn off PUTs water_sense_mode=off for the device."""
         device = BHyveDevice(
             {
-                "id": "device-4",
+                "id": "device-6",
                 "name": "Test",
                 "type": "sprinkler_timer",
-                "mac_address": "aa:bb:cc:dd:ee:04",
+                "mac_address": "aa:bb:cc:dd:ee:06",
                 "hardware_version": "HT25-0000",
                 "firmware_version": "0085",
                 "is_connected": True,
                 "status": {"run_mode": "auto"},
+                "water_sense_mode": "auto",
                 "zones": [
                     {"station": 1, "smart_watering_enabled": True},
                     {"station": 2, "smart_watering_enabled": True},
@@ -1395,18 +1396,20 @@ class TestBHyveSmartWateringSwitch:
             }
         )
         coordinator = create_mock_coordinator(
-            {"device-4": {"device": device, "history": [], "landscapes": {}}},
+            {"device-6": {"device": device, "history": [], "landscapes": {}}},
             {},
         )
         switch = self._create_switch(device, device["zones"][0], coordinator)
 
         await switch.async_turn_off()
-        coordinator.client.update_device.assert_called_once()
-        call_args = coordinator.client.update_device.call_args[0][0]
-        zones = call_args["zones"]
-        # Zone 1 should be disabled, zone 2 unchanged
-        assert zones[0]["smart_watering_enabled"] is False
-        assert zones[1]["smart_watering_enabled"] is True
+        coordinator.client.update_device.assert_called_once_with(
+            {
+                "id": "device-6",
+                "type": "sprinkler_timer",
+                "mac_address": "aa:bb:cc:dd:ee:06",
+                "water_sense_mode": "off",
+            }
+        )
 
     async def test_setup_creates_per_zone_switches(self, hass: HomeAssistant) -> None:
         """Test setup creates one smart watering switch per zone."""
@@ -1419,7 +1422,7 @@ class TestBHyveSmartWateringSwitch:
                 "hardware_version": "WT25G2-0001",
                 "firmware_version": "0087",
                 "is_connected": True,
-                "smart_watering_enabled": True,
+                "water_sense_mode": "auto",
                 "status": {
                     "run_mode": "auto",
                     "watering_status": None,


### PR DESCRIPTION
## Summary

- Fixes #434: toggling per-zone smart watering switches returned `400 Bad Request` from Orbit's `/v1/devices/{id}` endpoint.
- Orbit now treats smart watering as a device-level setting via `water_sense_mode` (`"auto"` enabled, `"off"` disabled). The previous payload (full zones list with `smart_watering_enabled` flipped) is no longer accepted.
- Per-zone smart watering entities are kept for backward compatibility (no change to entity IDs / names). Each switch now reads `device.water_sense_mode` and PUTs the device-level payload the web app uses:
  ```json
  {"device": {"id": "...", "type": "sprinkler_timer", "mac_address": "...", "water_sense_mode": "auto"|"off"}}
  ```
- Smart watering is device-wide: toggling any per-zone switch flips the master, and all switches on the device follow.
- Coordinator's smart-program websocket handler also mirrors the new state onto each zone's `smart_watering_enabled` so the valve attribute stays in sync.

## Test plan

- [x] `pytest tests/` — 165 passed, 5 skipped
- [x] `ruff check` + `ruff format --check` clean on changed files
- [x] Manual: toggle a per-zone smart watering switch in HA and confirm the request succeeds (200) and Orbit reflects the change
- [x] Manual: toggle smart watering from the B-hyve app and confirm HA switches follow within ~5 min (next coordinator refresh) or sooner via the smart_program websocket event