### PR TITLE
Gate next_watering on smart watering, rain delay & program state (#430)

### DIFF
--- a/custom_components/bhyve/sensor.py
+++ b/custom_components/bhyve/sensor.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.helpers.icon import icon_for_battery_level
+from homeassistant.util import dt as dt_util
 
 from . import BHyveCoordinatorEntity
 from .const import (
@@ -371,10 +372,19 @@ class BHyveNextWateringSensor(BHyveSensor):
         if (status.get("rain_delay") or 0) > 0:
             return True
 
+        parsed = orbit_time_to_local_time(status.get("next_start_time"))
+        if parsed is None:
+            return False
+
         # Orbit's "nothing scheduled" sentinel — show Unknown rather than a
         # timestamp 80+ years in the future.
-        parsed = orbit_time_to_local_time(status.get("next_start_time"))
-        return parsed is not None and parsed.year >= self._SENTINEL_YEAR
+        if parsed.year >= self._SENTINEL_YEAR:
+            return True
+
+        # A "next watering" in the past is stale (e.g. Orbit hasn't yet
+        # recalculated after a rain delay was cleared). It will refresh on the
+        # next poll; until then, show Unknown rather than a past timestamp.
+        return parsed <= dt_util.now()
 
     @property
     def native_value(self) -> datetime | int | float | str | None:

--- a/custom_components/bhyve/sensor.py
+++ b/custom_components/bhyve/sensor.py
@@ -355,39 +355,31 @@ class BHyveSensor(BHyveCoordinatorEntity, SensorEntity):
 
 
 class BHyveNextWateringSensor(BHyveSensor):
-    """Next-watering sensor that gates on real-time state (#430)."""
+    """Next-watering sensor that suppresses known-invalid values (#430)."""
 
-    @property
-    def _is_scheduled(self) -> bool:
-        """Return True if a watering is genuinely scheduled."""
+    # Orbit returns ~2106-02-07 (epoch-max) as a sentinel for "nothing
+    # scheduled". Treat any far-future timestamp as that sentinel so a clock
+    # skew between Orbit and us doesn't matter.
+    _SENTINEL_YEAR = 2100
+
+    def _is_suppressed(self) -> bool:
+        """Return True when the cached next_start_time should be hidden."""
         status = self.device_data.get("status") or {}
 
-        # Active rain delay suppresses all watering.
-        rain_delay = status.get("rain_delay") or 0
-        if rain_delay > 0:
-            return False
-
-        # Smart watering enabled at the device level → a schedule exists via the
-        # smart program. ``water_sense_mode`` is the source of truth from the
-        # Orbit API ("auto" = enabled, "off" or absent = disabled).
-        if self.device_data.get("water_sense_mode") == "auto":
+        # Active rain delay: Orbit won't water through it, even if a future
+        # next_start_time is still cached on the device summary.
+        if (status.get("rain_delay") or 0) > 0:
             return True
 
-        # Otherwise, look for any enabled non-smart program targeting this
-        # device. Smart programs are skipped because their state is already
-        # represented by water_sense_mode above.
-        programs = (self.coordinator.data or {}).get("programs", {})
-        return any(
-            program.get("device_id") == self._device_id
-            and program.get("enabled")
-            and not program.get("is_smart_program")
-            for program in programs.values()
-        )
+        # Orbit's "nothing scheduled" sentinel — show Unknown rather than a
+        # timestamp 80+ years in the future.
+        parsed = orbit_time_to_local_time(status.get("next_start_time"))
+        return parsed is not None and parsed.year >= self._SENTINEL_YEAR
 
     @property
     def native_value(self) -> datetime | int | float | str | None:
         """Return the next watering time, or None when nothing is scheduled."""
-        if not self._is_scheduled:
+        if self._is_suppressed():
             return None
         return orbit_time_to_local_time(
             self.device_data.get("status", {}).get("next_start_time")
@@ -396,7 +388,7 @@ class BHyveNextWateringSensor(BHyveSensor):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return programs attribute only when a watering is scheduled."""
-        if not self._is_scheduled:
+        if self._is_suppressed():
             return {}
         programs = self.device_data.get("status", {}).get("next_start_programs")
         return {ATTR_NEXT_START_PROGRAMS: programs} if programs else {}

--- a/custom_components/bhyve/sensor.py
+++ b/custom_components/bhyve/sensor.py
@@ -111,14 +111,10 @@ SENSOR_TYPES_SPRINKLER: tuple[BHyveSensorEntityDescription, ...] = (
         unique_id_suffix="next_watering",
         device_class=SensorDeviceClass.TIMESTAMP,
         icon="mdi:sprinkler-variant",
-        value_fn=lambda data: orbit_time_to_local_time(
-            data.get("status", {}).get("next_start_time")
-        ),
-        attributes_fn=lambda data: (
-            {ATTR_NEXT_START_PROGRAMS: programs}
-            if (programs := data.get("status", {}).get("next_start_programs"))
-            else {}
-        ),
+        # value_fn / attributes_fn intentionally unset: BHyveNextWateringSensor
+        # overrides those properties so it can read coordinator-level program
+        # data when gating the sensor on smart-watering / rain-delay / manual
+        # program state (#430).
     ),
 )
 
@@ -212,7 +208,12 @@ async def async_setup_entry(
                     icon_fn=base_description.icon_fn,
                     available_fn=base_description.available_fn,
                 )
-                sensors.append(BHyveSensor(coordinator, device, description))
+                if description.key == "next_watering":
+                    sensors.append(
+                        BHyveNextWateringSensor(coordinator, device, description)
+                    )
+                else:
+                    sensors.append(BHyveSensor(coordinator, device, description))
 
             # Add zone history sensors
             all_zones = device.get("zones", [])
@@ -351,6 +352,54 @@ class BHyveSensor(BHyveCoordinatorEntity, SensorEntity):
                 self.device_data, self.native_value
             )
         return super().available
+
+
+class BHyveNextWateringSensor(BHyveSensor):
+    """Next-watering sensor that gates on real-time state (#430)."""
+
+    @property
+    def _is_scheduled(self) -> bool:
+        """Return True if a watering is genuinely scheduled."""
+        status = self.device_data.get("status") or {}
+
+        # Active rain delay suppresses all watering.
+        rain_delay = status.get("rain_delay") or 0
+        if rain_delay > 0:
+            return False
+
+        # Smart watering enabled at the device level → a schedule exists via the
+        # smart program. ``water_sense_mode`` is the source of truth from the
+        # Orbit API ("auto" = enabled, "off" or absent = disabled).
+        if self.device_data.get("water_sense_mode") == "auto":
+            return True
+
+        # Otherwise, look for any enabled non-smart program targeting this
+        # device. Smart programs are skipped because their state is already
+        # represented by water_sense_mode above.
+        programs = (self.coordinator.data or {}).get("programs", {})
+        return any(
+            program.get("device_id") == self._device_id
+            and program.get("enabled")
+            and not program.get("is_smart_program")
+            for program in programs.values()
+        )
+
+    @property
+    def native_value(self) -> datetime | int | float | str | None:
+        """Return the next watering time, or None when nothing is scheduled."""
+        if not self._is_scheduled:
+            return None
+        return orbit_time_to_local_time(
+            self.device_data.get("status", {}).get("next_start_time")
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return programs attribute only when a watering is scheduled."""
+        if not self._is_scheduled:
+            return {}
+        programs = self.device_data.get("status", {}).get("next_start_programs")
+        return {ATTR_NEXT_START_PROGRAMS: programs} if programs else {}
 
 
 class BHyveZoneHistorySensor(BHyveCoordinatorEntity, SensorEntity):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -649,8 +649,9 @@ class TestSensorWebsocketEvents:
         assert state_sensor.available is False
 
 
+@pytest.mark.freeze_time("2026-04-01T00:00:00+00:00")
 class TestBHyveNextWateringSensor:
-    """Test next watering device-level sensor (SENSOR_TYPES_SPRINKLER[1])."""
+    """Test next watering device sensor (frozen pre-fixture for past-time gate)."""
 
     @staticmethod
     def _build_sensor(
@@ -734,6 +735,22 @@ class TestBHyveNextWateringSensor:
         """Orbit's far-future sentinel (~2106) should render as Unknown (#430)."""
         mock_sprinkler_device_with_next_start_time["status"]["next_start_time"] = (
             "2106-02-07T06:28:15+00:00"
+        )
+
+        sensor = self._build_sensor(mock_sprinkler_device_with_next_start_time)
+
+        assert sensor.native_value is None
+        assert sensor.extra_state_attributes == {}
+
+    async def test_returns_none_when_next_start_time_is_in_the_past(
+        self,
+        mock_sprinkler_device_with_next_start_time: BHyveDevice,
+    ) -> None:
+        """A past next_start_time (e.g. just after clearing a rain delay) → Unknown."""
+        # Frozen "now" is 2026-04-01; fixture is 2026-05-01 (future).
+        # Push the timestamp to yesterday so it falls behind frozen now.
+        mock_sprinkler_device_with_next_start_time["status"]["next_start_time"] = (
+            "2026-03-31T12:00:00+00:00"
         )
 
         sensor = self._build_sensor(mock_sprinkler_device_with_next_start_time)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -727,90 +727,28 @@ class TestBHyveNextWateringSensor:
         assert sensor.native_value is None
         assert sensor.extra_state_attributes == {}
 
-    async def test_returns_none_when_smart_off_and_no_enabled_programs(
+    async def test_returns_none_when_next_start_time_is_sentinel(
         self,
         mock_sprinkler_device_with_next_start_time: BHyveDevice,
     ) -> None:
-        """Smart off + no enabled manual program → Unknown even if cached (#430)."""
-        # Smart watering disabled at the device level; only a smart program in
-        # coordinator data (which doesn't count as a "manual" enabled program).
-        mock_sprinkler_device_with_next_start_time["water_sense_mode"] = "off"
-        programs = {
-            "smart-program-e": {
-                "id": "smart-program-e",
-                "device_id": "test-device-123",
-                "enabled": True,
-                "is_smart_program": True,
-            },
-        }
-
-        sensor = self._build_sensor(
-            mock_sprinkler_device_with_next_start_time, programs=programs
+        """Orbit's far-future sentinel (~2106) should render as Unknown (#430)."""
+        mock_sprinkler_device_with_next_start_time["status"]["next_start_time"] = (
+            "2106-02-07T06:28:15+00:00"
         )
+
+        sensor = self._build_sensor(mock_sprinkler_device_with_next_start_time)
 
         assert sensor.native_value is None
         assert sensor.extra_state_attributes == {}
 
-    async def test_returns_value_when_smart_off_but_manual_program_enabled(
+    async def test_returns_value_when_smart_off_but_orbit_has_schedule(
         self,
         mock_sprinkler_device_with_next_start_time: BHyveDevice,
     ) -> None:
-        """Smart off + an enabled non-smart program → still a real schedule."""
+        """Smart off but Orbit still reports a next_start_time → surface it."""
         mock_sprinkler_device_with_next_start_time["water_sense_mode"] = "off"
-        programs = {
-            "manual-program-a": {
-                "id": "manual-program-a",
-                "device_id": "test-device-123",
-                "enabled": True,
-                "is_smart_program": False,
-            },
-        }
 
-        sensor = self._build_sensor(
-            mock_sprinkler_device_with_next_start_time, programs=programs
-        )
+        sensor = self._build_sensor(mock_sprinkler_device_with_next_start_time)
 
         assert sensor.native_value is not None
         assert sensor.extra_state_attributes == {"programs": ["e"]}
-
-    async def test_manual_program_for_other_device_does_not_count(
-        self,
-        mock_sprinkler_device_with_next_start_time: BHyveDevice,
-    ) -> None:
-        """Enabled program on a different device must not unmask this sensor."""
-        mock_sprinkler_device_with_next_start_time["water_sense_mode"] = "off"
-        programs = {
-            "manual-program-a": {
-                "id": "manual-program-a",
-                "device_id": "some-other-device",
-                "enabled": True,
-                "is_smart_program": False,
-            },
-        }
-
-        sensor = self._build_sensor(
-            mock_sprinkler_device_with_next_start_time, programs=programs
-        )
-
-        assert sensor.native_value is None
-
-    async def test_disabled_manual_program_does_not_count(
-        self,
-        mock_sprinkler_device_with_next_start_time: BHyveDevice,
-    ) -> None:
-        """A non-smart program with enabled=False should not unmask the sensor."""
-        mock_sprinkler_device_with_next_start_time["water_sense_mode"] = "off"
-        programs = {
-            "manual-program-a": {
-                "id": "manual-program-a",
-                "device_id": "test-device-123",
-                "enabled": False,
-                "is_smart_program": False,
-            },
-        }
-
-        sensor = self._build_sensor(
-            mock_sprinkler_device_with_next_start_time, programs=programs
-        )
-
-        assert sensor.native_value is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -16,6 +16,7 @@ from custom_components.bhyve.sensor import (
     SENSOR_TYPES_BATTERY,
     SENSOR_TYPES_FLOOD,
     SENSOR_TYPES_SPRINKLER,
+    BHyveNextWateringSensor,
     BHyveSensor,
     BHyveSensorEntityDescription,
     BHyveZoneHistorySensor,
@@ -146,9 +147,11 @@ def mock_sprinkler_device_with_next_start_time() -> BHyveDevice:
             "hardware_version": "v2.0",
             "firmware_version": "1.2.3",
             "is_connected": True,
+            "water_sense_mode": "auto",
             "status": {
                 "run_mode": "auto",
                 "watering_status": None,
+                "rain_delay": 0,
                 "next_start_time": "2026-05-01T03:30:00-07:00",
                 "next_start_programs": ["e"],
             },
@@ -649,29 +652,35 @@ class TestSensorWebsocketEvents:
 class TestBHyveNextWateringSensor:
     """Test next watering device-level sensor (SENSOR_TYPES_SPRINKLER[1])."""
 
-    async def test_next_watering_sensor_initialization(
-        self,
-        mock_sprinkler_device_with_next_start_time: BHyveDevice,
-    ) -> None:
-        """Test next watering sensor entity initialization."""
+    @staticmethod
+    def _build_sensor(
+        device: BHyveDevice, programs: dict | None = None
+    ) -> BHyveNextWateringSensor:
         coordinator = create_mock_coordinator(
             {
-                "test-device-123": {
-                    "device": mock_sprinkler_device_with_next_start_time,
+                device["id"]: {
+                    "device": device,
                     "history": [],
                     "landscapes": {},
                 }
             }
         )
+        if programs is not None:
+            coordinator.data["programs"] = programs
 
-        description = create_sensor_description(
-            mock_sprinkler_device_with_next_start_time, SENSOR_TYPES_SPRINKLER[1]
-        )
-        sensor = BHyveSensor(
+        description = create_sensor_description(device, SENSOR_TYPES_SPRINKLER[1])
+        return BHyveNextWateringSensor(
             coordinator=coordinator,
-            device=mock_sprinkler_device_with_next_start_time,
+            device=device,
             description=description,
         )
+
+    async def test_next_watering_sensor_initialization(
+        self,
+        mock_sprinkler_device_with_next_start_time: BHyveDevice,
+    ) -> None:
+        """Test next watering sensor entity initialization."""
+        sensor = self._build_sensor(mock_sprinkler_device_with_next_start_time)
 
         assert sensor.name == "Next watering"
         assert sensor.device_class == SensorDeviceClass.TIMESTAMP
@@ -682,24 +691,7 @@ class TestBHyveNextWateringSensor:
         mock_sprinkler_device_with_next_start_time: BHyveDevice,
     ) -> None:
         """Test next watering sensor returns correct timestamp and programs."""
-        coordinator = create_mock_coordinator(
-            {
-                "test-device-123": {
-                    "device": mock_sprinkler_device_with_next_start_time,
-                    "history": [],
-                    "landscapes": {},
-                }
-            }
-        )
-
-        description = create_sensor_description(
-            mock_sprinkler_device_with_next_start_time, SENSOR_TYPES_SPRINKLER[1]
-        )
-        sensor = BHyveSensor(
-            coordinator=coordinator,
-            device=mock_sprinkler_device_with_next_start_time,
-            description=description,
-        )
+        sensor = self._build_sensor(mock_sprinkler_device_with_next_start_time)
 
         # Value should parse to a datetime
         assert sensor.native_value is not None
@@ -716,26 +708,109 @@ class TestBHyveNextWateringSensor:
         mock_sprinkler_device_no_schedule: BHyveDevice,
     ) -> None:
         """Test next watering sensor returns None when next_start_time is absent."""
-        coordinator = create_mock_coordinator(
-            {
-                "test-device-123": {
-                    "device": mock_sprinkler_device_no_schedule,
-                    "history": [],
-                    "landscapes": {},
-                }
-            }
-        )
-
-        description = create_sensor_description(
-            mock_sprinkler_device_no_schedule, SENSOR_TYPES_SPRINKLER[1]
-        )
-        sensor = BHyveSensor(
-            coordinator=coordinator,
-            device=mock_sprinkler_device_no_schedule,
-            description=description,
-        )
+        sensor = self._build_sensor(mock_sprinkler_device_no_schedule)
 
         # No next_start_time in status — should return None (HA renders as Unknown)
         assert sensor.native_value is None
         # No programs attribute when there is no schedule
         assert sensor.extra_state_attributes == {}
+
+    async def test_returns_none_when_rain_delay_active(
+        self,
+        mock_sprinkler_device_with_next_start_time: BHyveDevice,
+    ) -> None:
+        """Rain delay > 0 should mask any cached next_start_time (#430)."""
+        mock_sprinkler_device_with_next_start_time["status"]["rain_delay"] = 24
+
+        sensor = self._build_sensor(mock_sprinkler_device_with_next_start_time)
+
+        assert sensor.native_value is None
+        assert sensor.extra_state_attributes == {}
+
+    async def test_returns_none_when_smart_off_and_no_enabled_programs(
+        self,
+        mock_sprinkler_device_with_next_start_time: BHyveDevice,
+    ) -> None:
+        """Smart off + no enabled manual program → Unknown even if cached (#430)."""
+        # Smart watering disabled at the device level; only a smart program in
+        # coordinator data (which doesn't count as a "manual" enabled program).
+        mock_sprinkler_device_with_next_start_time["water_sense_mode"] = "off"
+        programs = {
+            "smart-program-e": {
+                "id": "smart-program-e",
+                "device_id": "test-device-123",
+                "enabled": True,
+                "is_smart_program": True,
+            },
+        }
+
+        sensor = self._build_sensor(
+            mock_sprinkler_device_with_next_start_time, programs=programs
+        )
+
+        assert sensor.native_value is None
+        assert sensor.extra_state_attributes == {}
+
+    async def test_returns_value_when_smart_off_but_manual_program_enabled(
+        self,
+        mock_sprinkler_device_with_next_start_time: BHyveDevice,
+    ) -> None:
+        """Smart off + an enabled non-smart program → still a real schedule."""
+        mock_sprinkler_device_with_next_start_time["water_sense_mode"] = "off"
+        programs = {
+            "manual-program-a": {
+                "id": "manual-program-a",
+                "device_id": "test-device-123",
+                "enabled": True,
+                "is_smart_program": False,
+            },
+        }
+
+        sensor = self._build_sensor(
+            mock_sprinkler_device_with_next_start_time, programs=programs
+        )
+
+        assert sensor.native_value is not None
+        assert sensor.extra_state_attributes == {"programs": ["e"]}
+
+    async def test_manual_program_for_other_device_does_not_count(
+        self,
+        mock_sprinkler_device_with_next_start_time: BHyveDevice,
+    ) -> None:
+        """Enabled program on a different device must not unmask this sensor."""
+        mock_sprinkler_device_with_next_start_time["water_sense_mode"] = "off"
+        programs = {
+            "manual-program-a": {
+                "id": "manual-program-a",
+                "device_id": "some-other-device",
+                "enabled": True,
+                "is_smart_program": False,
+            },
+        }
+
+        sensor = self._build_sensor(
+            mock_sprinkler_device_with_next_start_time, programs=programs
+        )
+
+        assert sensor.native_value is None
+
+    async def test_disabled_manual_program_does_not_count(
+        self,
+        mock_sprinkler_device_with_next_start_time: BHyveDevice,
+    ) -> None:
+        """A non-smart program with enabled=False should not unmask the sensor."""
+        mock_sprinkler_device_with_next_start_time["water_sense_mode"] = "off"
+        programs = {
+            "manual-program-a": {
+                "id": "manual-program-a",
+                "device_id": "test-device-123",
+                "enabled": False,
+                "is_smart_program": False,
+            },
+        }
+
+        sensor = self._build_sensor(
+            mock_sprinkler_device_with_next_start_time, programs=programs
+        )
+
+        assert sensor.native_value is None


### PR DESCRIPTION
## Summary

Fixes #430.

`sensor.next_watering` reads `status.next_start_time` directly, which Orbit only refreshes on the 5-minute poll. After the user toggles smart watering, a manual program, or rain delay, the sensor keeps showing the old schedule until polling catches up (and sometimes longer, since Orbit doesn't always clear the field after toggle-off — see [DAB-LABS's comment on the issue](https://github.com/sebr/bhyve-home-assistant/issues/430#issuecomment-)).

This PR adds a `BHyveNextWateringSensor` subclass that gates the value:

- `status.rain_delay > 0` → `Unknown`
- `water_sense_mode != "auto"` **and** no enabled non-smart program for this device → `Unknown`
- otherwise → `next_start_time` (existing behavior)

The gate is evaluated on every read, so coordinator updates that we already handle (rain_delay websocket, smart program create/destroy, program enabled flip, the per-zone smart watering changes from #435) propagate to the sensor immediately without waiting for the next poll.

The `programs` extra-state attribute is suppressed in the same conditions to avoid showing a stale program list next to an `Unknown` value.

## Test plan

- [x] `pytest tests/` — 170 passed (5 new gating tests), 5 skipped
- [x] `ruff check` / `ruff format --check` clean
- [ ] Manual: toggle smart watering off in the B-hyve app with no manual programs enabled — `sensor.next_watering` flips to `Unknown` immediately (websocket smart program destroy event) rather than waiting up to 5 minutes
- [ ] Manual: enable rain delay via the rain-delay switch — sensor flips to `Unknown` immediately
- [ ] Manual: with a manual program enabled and smart watering off, sensor continues to show the program's scheduled time