### PR TITLE
fix: log the unexpected error behind a cannot_connect result

### DIFF
--- a/custom_components/bhyve/config_flow.py
+++ b/custom_components/bhyve/config_flow.py
@@ -57,7 +57,8 @@ class BHyveConfigFlow(ConfigFlow, domain=DOMAIN):
             return None  # noqa: TRY300
         except AuthenticationError:
             return {"base": "invalid_auth"}
-        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("BHyve login failed with an unexpected error")
             return {"base": "cannot_connect"}
 
     async def async_step_user(


### PR DESCRIPTION
The broad `except` in `async_auth` catches everything that is not an `AuthenticationError` and returns `cannot_connect`. Nothing reaches the log. So a failed setup gives you no way to tell a network problem from an API change from a parsing error.

I hit this chasing my own login failures, before I worked out that 4.1.2 had already fixed the real cause with the WAF headers. Adding this one line locally was how I found that out.

User-facing behaviour is unchanged. The `BLE001` noqa goes with it, since ruff exempts a blind except whose handler logs through `logging.exception`. `ruff check` is clean and the suite passes on 4.1.2, 165 passed and 5 skipped.
