### PR TITLE
feat: support run_times in the update_program service

### DIFF
--- a/custom_components/bhyve/switch.py
+++ b/custom_components/bhyve/switch.py
@@ -63,6 +63,7 @@ SERVICE_UPDATE_PROGRAM = "update_program"
 ATTR_START_TIMES = "start_times"
 ATTR_FREQUENCY = "frequency"
 ATTR_BUDGET = "budget"
+ATTR_RUN_TIMES = "run_times"
 
 BUDGET_MIN = 0
 BUDGET_MAX = 200
@@ -88,6 +89,21 @@ FREQUENCY_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
+# A run_times entry: station id + minutes to run for that station.
+RUN_TIMES_SCHEMA = vol.All(
+    [
+        vol.Schema(
+            {
+                vol.Required("station"): vol.Coerce(int),
+                vol.Required("run_time"): vol.All(
+                    vol.Coerce(int), vol.Range(min=0)
+                ),
+            },
+            extra=vol.ALLOW_EXTRA,
+        )
+    ]
+)
+
 UPDATE_PROGRAM_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_ENTITY_ID): cv.comp_entity_ids,
@@ -98,6 +114,7 @@ UPDATE_PROGRAM_SCHEMA = vol.Schema(
         vol.Optional(ATTR_BUDGET): vol.All(
             vol.Coerce(int), vol.Range(min=BUDGET_MIN, max=BUDGET_MAX)
         ),
+        vol.Optional(ATTR_RUN_TIMES): RUN_TIMES_SCHEMA,
     }
 )
 
@@ -316,14 +333,23 @@ class BHyveProgramSwitch(BHyveCoordinatorEntity, SwitchEntity):
         start_times: list[str] | None = None,
         frequency: dict | None = None,
         budget: int | None = None,
+        run_times: list[dict] | None = None,
     ) -> None:
         """Update configurable fields on a non-smart program."""
         if self.program_data.get("is_smart_program"):
             msg = "Cannot update configuration of a smart program"
             raise ServiceValidationError(msg)
 
-        if start_times is None and frequency is None and budget is None:
-            msg = "At least one of start_times, frequency or budget must be provided"
+        if (
+            start_times is None
+            and frequency is None
+            and budget is None
+            and run_times is None
+        ):
+            msg = (
+                "At least one of start_times, frequency, budget or run_times "
+                "must be provided"
+            )
             raise ServiceValidationError(msg)
 
         program = BHyveTimerProgram(
@@ -339,6 +365,9 @@ class BHyveProgramSwitch(BHyveCoordinatorEntity, SwitchEntity):
         if budget is not None:
             program["budget"] = budget
             changed.append("budget")
+        if run_times is not None:
+            program["run_times"] = run_times
+            changed.append("run_times")
 
         _LOGGER.info(
             "Updating program %s, changed fields: %s", self._program_id, changed

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -606,6 +606,33 @@ class TestBHyveProgramSwitch:
         assert payload["id"] == TEST_PROGRAM_ID
         assert payload["device_id"] == TEST_DEVICE_ID
 
+    async def test_update_program_config_run_times(
+        self,
+        mock_sprinkler_device: BHyveDevice,
+        mock_timer_program: BHyveTimerProgram,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        """Test updating run_times (per-zone minutes) overrides that field."""
+        description = create_program_switch_description()
+        switch = BHyveProgramSwitch(
+            coordinator=mock_coordinator,
+            device=mock_sprinkler_device,
+            program=mock_timer_program,
+            description=description,
+        )
+
+        run_times = [{"station": 1, "run_time": 5}, {"station": 5, "run_time": 7}]
+        await switch.async_update_program_config(run_times=run_times)
+
+        mock_coordinator.client.update_program.assert_called_once()
+        program_id, payload = mock_coordinator.client.update_program.call_args[0]
+        assert program_id == TEST_PROGRAM_ID
+        assert payload["run_times"] == run_times
+        # Unchanged fields are preserved
+        assert payload["start_times"] == mock_timer_program["start_times"]
+        assert payload["frequency"] == mock_timer_program["frequency"]
+        assert payload["enabled"] is True
+
     async def test_update_program_config_budget_only(
         self,
         mock_sprinkler_device: BHyveDevice,


### PR DESCRIPTION
## Summary

Adds the ability to write **per-zone run times** (`run_times`) through the `bhyve.update_program` **service**. Previously the service only accepted `start_times`, `frequency` and `budget` — even though `run_times` is part of the program data model and is already exposed as an entity attribute.

This lets automations and integrations set **which stations a program waters and for how long** (e.g. to match a water-district irrigation schedule), rather than only editing the schedule.

## Changes

- Add `ATTR_RUN_TIMES` constant and a `RUN_TIMES_SCHEMA` entry to `UPDATE_PROGRAM_SCHEMA`
- Accept + forward `run_times` in `async_update_program_config`
- Include `run_times` in the "at least one field required" guard
- Add a unit test mirroring the existing per-field tests

## Example usage

```yaml
service: bhyve.update_program
data:
  entity_id: switch.sprinklers_program_1
  run_times:
    - station: 1
      run_time: 5
    - station: 5
      run_time: 7
```

This sets stations 1 (5 min) and 5 (7 min) in program 1.

## Testing

- Added `test_update_program_config_run_times` in `tests/test_switch.py` (mirrors existing `start_times`/`frequency`/`budget` tests)
- Syntax verified on both Python 3.11 and 3.13

## Notes

- Mirror(s) the existing pattern for `start_times`, `frequency`, budget exactly
- Verified against a live Orbit B-hyve controller (stations 1–5) — per-zone minutes update and persist after a poll cycle
