### PR TITLE
feat: add firmware-version diagnostic sensor

### DIFF
--- a/custom_components/bhyve/sensor.py
+++ b/custom_components/bhyve/sensor.py
@@ -120,6 +120,16 @@ SENSOR_TYPES_SPRINKLER: tuple[BHyveSensorEntityDescription, ...] = (
             else {}
         ),
     ),
+    BHyveSensorEntityDescription(
+        key="firmware_version",
+        translation_key="firmware_version",
+        name="Firmware version",
+        unique_id_suffix="firmware_version",
+        icon="mdi:chip",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.get("firmware_version") or None,
+        available_fn=lambda _data, value: value is not None,
+    ),
 )
 
 SENSOR_TYPES_FLOOD: tuple[BHyveSensorEntityDescription, ...] = (

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -739,3 +739,111 @@ class TestBHyveNextWateringSensor:
         assert sensor.native_value is None
         # No programs attribute when there is no schedule
         assert sensor.extra_state_attributes == {}
+
+
+class TestBHyveFirmwareSensor:
+    """Test firmware-version diagnostic sensor (SENSOR_TYPES_SPRINKLER[2])."""
+
+    @pytest.fixture
+    def mock_sprinkler_with_firmware(self) -> BHyveDevice:
+        """Mock sprinkler with a firmware version."""
+        return BHyveDevice(
+            {
+                "id": "test-device-123",
+                "name": "Test Sprinkler",
+                "type": "sprinkler_timer",
+                "mac_address": "aa:bb:cc:dd:ee:ff",
+                "firmware_version": "1.2.3",
+                "is_connected": True,
+                "status": {"run_mode": "auto"},
+                "zones": [{"station": "1", "name": "Front Lawn"}],
+            }
+        )
+
+    @pytest.fixture
+    def mock_sprinkler_no_firmware(self) -> BHyveDevice:
+        """Mock sprinkler without a firmware version."""
+        return BHyveDevice(
+            {
+                "id": "test-device-123",
+                "name": "Test Sprinkler",
+                "type": "sprinkler_timer",
+                "mac_address": "aa:bb:cc:dd:ee:ff",
+                "is_connected": True,
+                "status": {"run_mode": "auto"},
+                "zones": [{"station": "1", "name": "Front Lawn"}],
+            }
+        )
+
+    async def test_firmware_sensor_initialization(
+        self, mock_sprinkler_with_firmware: BHyveDevice
+    ) -> None:
+        """Test firmware sensor entity initialization."""
+        coordinator = create_mock_coordinator(
+            {
+                "test-device-123": {
+                    "device": mock_sprinkler_with_firmware,
+                    "history": [],
+                    "landscapes": {},
+                }
+            }
+        )
+        description = create_sensor_description(
+            mock_sprinkler_with_firmware, SENSOR_TYPES_SPRINKLER[2]
+        )
+        sensor = BHyveSensor(
+            coordinator=coordinator,
+            device=mock_sprinkler_with_firmware,
+            description=description,
+        )
+        assert sensor.name == "Firmware version"
+        assert sensor.entity_category == EntityCategory.DIAGNOSTIC
+        assert sensor._attr_unique_id.endswith(":firmware_version")
+
+    async def test_firmware_sensor_value(
+        self, mock_sprinkler_with_firmware: BHyveDevice
+    ) -> None:
+        """Test firmware sensor returns the device firmware version."""
+        coordinator = create_mock_coordinator(
+            {
+                "test-device-123": {
+                    "device": mock_sprinkler_with_firmware,
+                    "history": [],
+                    "landscapes": {},
+                }
+            }
+        )
+        description = create_sensor_description(
+            mock_sprinkler_with_firmware, SENSOR_TYPES_SPRINKLER[2]
+        )
+        sensor = BHyveSensor(
+            coordinator=coordinator,
+            device=mock_sprinkler_with_firmware,
+            description=description,
+        )
+        assert sensor.native_value == "1.2.3"
+
+    async def test_firmware_sensor_unavailable_without_version(
+        self, mock_sprinkler_no_firmware: BHyveDevice
+    ) -> None:
+        """Test firmware sensor is unavailable when device has no version."""
+        coordinator = create_mock_coordinator(
+            {
+                "test-device-123": {
+                    "device": mock_sprinkler_no_firmware,
+                    "history": [],
+                    "landscapes": {},
+                }
+            }
+        )
+        description = create_sensor_description(
+            mock_sprinkler_no_firmware, SENSOR_TYPES_SPRINKLER[2]
+        )
+        sensor = BHyveSensor(
+            coordinator=coordinator,
+            device=mock_sprinkler_no_firmware,
+            description=description,
+        )
+        assert sensor.native_value is None
+        assert sensor.available is False
+


### PR DESCRIPTION
## Summary
Adds a **firmware-version diagnostic sensor** to the sprinkler device.

The device registry already records `firmware_version` as the device's `sw_version`, but it was not surfaced as an entity. This exposes it as a `diagnostic` sensor so it can be shown on a dashboard or checked in automations.

## Changes
- Adds `sensor.<device>_firmware_version` (entity_category `diagnostic`)
- Value = the device's `firmware_version` string
- `unavailable` when the device reports no firmware version
- Tests covering present and absent firmware

## Notes
Connectivity (`binary_sensor.<device>_connectivity`) and fault detection already exist; this closes the remaining obvious health gap by surfacing firmware version as an entity.
