### PR TITLE
Fix manual_preset_runtime not reflecting coordinator updates

### DIFF
--- a/custom_components/bhyve/coordinator.py
+++ b/custom_components/bhyve/coordinator.py
@@ -307,10 +307,14 @@ class BHyveDataUpdateCoordinator(DataUpdateCoordinator):
                     device_data["status"][key] = event_data[key]
 
         elif event == EVENT_SET_MANUAL_PRESET_TIME:
-            # Update manual preset runtime
-            if "status" not in device_data:
-                device_data["status"] = {}
-            device_data["status"]["manual_preset_runtime"] = event_data.get("runtime")
+            # The device echoes the new preset back on the same key it was sent
+            # on: {"event": "set_manual_preset_runtime", "seconds": 480, ...}.
+            # Write it to the device-level key the REST device object uses
+            # (manual_preset_runtime_sec) so websocket echoes and poll refreshes
+            # land in the same place. Both are seconds, so no conversion.
+            seconds = event_data.get("seconds")
+            if seconds is not None:
+                device_data["manual_preset_runtime_sec"] = seconds
 
         # Notify all listening entities
         self.async_set_updated_data(self.data)

--- a/custom_components/bhyve/valve.py
+++ b/custom_components/bhyve/valve.py
@@ -272,10 +272,20 @@ class BHyveZoneValve(BHyveCoordinatorEntity, ValveEntity):
         self._entity_picture: str | None = zone.get("image_url")
         self._zone_name: str = zone_name
         self._smart_watering_enabled: bool = zone.get("smart_watering_enabled", False)
-        self._manual_preset_runtime: int = device.get(
+        self._initial_programs = device_programs
+
+    @property
+    def _manual_preset_runtime(self) -> int:
+        """
+        Return the device's manual preset runtime, in seconds.
+
+        Read from live coordinator data (like `is_closed` and the rest of this
+        entity) so a `set_manual_preset_runtime` websocket echo or a poll
+        refresh is reflected without re-creating the entity.
+        """
+        return self.device_data.get(
             "manual_preset_runtime_sec", DEFAULT_MANUAL_RUNTIME.seconds
         )
-        self._initial_programs = device_programs
 
     @property
     def is_closed(self) -> bool:

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -521,3 +521,68 @@ async def test_valve_does_not_toggle_on_change_mode_during_watering(
             }
         )
         assert valve.is_closed is True, "valve should close when device_idle arrives"
+
+
+async def test_valve_manual_preset_runtime_reflects_coordinator_update(
+    hass: HomeAssistant,
+    mock_sprinkler_device: BHyveDevice,
+    mock_zone_data: BHyveZone,
+) -> None:
+    """
+    Regression for issue #478: preset runtime must update after entity setup.
+
+    The `set_manual_preset_runtime` websocket echo carries the new value on the
+    `seconds` key. Drive a real coordinator through that event and assert the
+    already-constructed entity reports the new value, and waters for it.
+    """
+    client = MagicMock()
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    coordinator = BHyveDataUpdateCoordinator(hass, client, entry)
+    device_id = mock_sprinkler_device["id"]
+    coordinator.data = {
+        "devices": {
+            device_id: {
+                "device": dict(mock_sprinkler_device),
+                "history": [],
+                "landscapes": {},
+            }
+        },
+        "programs": {},
+    }
+    coordinator.client = MagicMock()
+    coordinator.client.send_message = AsyncMock()
+
+    valve = BHyveZoneValve(
+        coordinator=coordinator,
+        device=coordinator.data["devices"][device_id]["device"],
+        zone=mock_zone_data,
+        zone_name="Front Yard",
+        device_programs=[],
+    )
+
+    # Device has no preset configured, so the entity falls back to the default.
+    assert valve.extra_state_attributes["manual_preset_runtime"] == 300
+
+    with patch.object(coordinator, "async_set_updated_data"):
+        await coordinator.async_handle_device_event(
+            {
+                "event": "set_manual_preset_runtime",
+                "device_id": device_id,
+                "seconds": TEST_PRESET_RUNTIME_SECONDS,
+                "timestamp": "2020-01-18T17:00:35.000Z",
+            }
+        )
+
+    # Same entity instance, no re-creation.
+    assert (
+        valve.extra_state_attributes["manual_preset_runtime"]
+        == TEST_PRESET_RUNTIME_SECONDS
+    )
+
+    # The echoed value is seconds, so opening the valve waters for 8 minutes.
+    await valve.async_open_valve()
+    sent_message = coordinator.client.send_message.call_args[0][0]
+    assert sent_message["stations"] == [
+        {"station": mock_zone_data["station"], "run_time": 8.0}
+    ]


### PR DESCRIPTION
Fixes #478

## The bug

`BHyveZoneValve` reads the device's manual preset runtime **once**, in `__init__`:

```python
self._manual_preset_runtime: int = device.get(
    "manual_preset_runtime_sec", DEFAULT_MANUAL_RUNTIME.seconds
)
```

The coordinator's `set_manual_preset_runtime` handler wrote the echoed value somewhere else entirely — `device_data["status"]["manual_preset_runtime"]` (`coordinator.py:313`). Different key, different dict, no reader anywhere in the codebase. The two never connected, so the entity never observed a successful write: the `manual_preset_runtime` attribute stayed at its setup-time value, and `async_open_valve()` kept watering for the stale duration until Home Assistant was restarted.

The handler also read the **wrong source key**. The event carries the value on `seconds`, not `runtime`, so `event_data.get("runtime")` was writing `None` on every event regardless of where it landed.

## What changed

**`valve.py`** — `_manual_preset_runtime` becomes a property backed by live coordinator data, using the same `self.device_data` accessor that `is_closed` and every other live attribute on this entity already use. No new pattern introduced; both existing call sites (`extra_state_attributes` and `async_open_valve`) are unchanged.

**`coordinator.py`** — the handler now reads `event_data["seconds"]` and writes it to `device_data["manual_preset_runtime_sec"]`, the same device-level key the REST device object supplies. Websocket echoes and the 5-minute poll refresh now land in the same place, so a poll can't silently revert an echoed value (writing to `status` would have been dropped on the next refresh, since the poll replaces the device dict wholesale). It also guards against `None` so a malformed event can't clobber a good value.

## The units question — resolved, not guessed

The issue flagged an open question: the outbound call sends `{"seconds": minutes * 60}` but the field name on the way back didn't confirm the unit. It resolves definitively to **seconds**, so no conversion is needed. Three independent pieces of evidence:

1. **The real observed payload is recorded in this repo's own history.** `valve.py` immediately before the coordinator refactor (`49ae6a2^`, line 448) documents a captured event verbatim:
   ```
   {'event': 'set_manual_preset_runtime', 'device_id': 'id', 'seconds': 480, 'timestamp': '2020-01-18T17:00:35.000Z'}
   ```
   Same key `seconds` inbound as outbound, and `480` = 8 minutes × 60. It was added in 9035224 ("Listen and respond to manual preset runtime", Jan 2020) by the maintainer alongside working handling code.

2. **The pre-refactor handler consumed it as seconds.** Same file, lines 487-491: `manual_preset_runtime = data.get("seconds")` assigned straight to `self._manual_preset_runtime` with no conversion. The `runtime`/`status` version in `coordinator.py` was introduced by the coordinator migration (49ae6a2) and is a regression against that working code.

3. **Everything downstream already treats the field as seconds.** The device-level key is literally named `manual_preset_runtime_sec` (6ddde20), its fallback is `timedelta(...).seconds`, `async_open_valve` divides by 60 to get minutes, and the README documents the attribute as "the number of seconds to run zone watering when the valve is opened."

Nothing needs maintainer confirmation here — but if the cloud has since started sending a differently-shaped payload on this event, the `seconds` key is now the single place to adjust.

## Tests

Added `test_valve_manual_preset_runtime_reflects_coordinator_update` in `tests/test_valve.py`, following the existing `test_valve_does_not_toggle_on_change_mode_during_watering` pattern: it drives a **real** `BHyveDataUpdateCoordinator` through an actual `set_manual_preset_runtime` event and asserts the already-constructed entity reports the new value — no re-instantiation. It also asserts `async_open_valve()` then sends `run_time: 8.0` minutes, which pins the seconds→minutes handling end to end.

Verified by actually reverting, not by assumption:

- **Before the fix:** `FAILED — assert 300 == 480` (the stale setup-time value).
- **After the fix:** passes.
- **Full suite:** 166 passed, 5 skipped. `ruff format --check` and `ruff check` both clean against this repo's `.ruff.toml`.

## How this surfaced

Found while building a third-party Lovelace card ([reypm/Orbit-BHyve-Custom-Card](https://github.com/reypm/Orbit-BHyve-Custom-Card)) that reads the `manual_preset_runtime` attribute off the valve entity — the value never changed after a service call, which led back to this.
