### PR TITLE
Run development on the host without a dev container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ core
 
 .claude/settings.local.json
 .env.local
+
+
+# portree runtime state
+.portree/

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ core
 .venv
 
 .claude/settings.local.json
+.env.local

--- a/.portree.toml
+++ b/.portree.toml
@@ -1,0 +1,13 @@
+# portree per-worktree dev server config. `portree up` runs Home Assistant on a
+# port it picks from the range below and routes <branch>.localhost:8100 to it.
+# scripts/develop reads the $PORT portree assigns.
+#
+#   portree up            start HA for this worktree
+#   portree ls --json     find its direct_url
+#   portree logs          tail its output
+#   portree down          stop it
+[services.hass]
+command = "scripts/develop"
+dir = "."
+port_range = { min = 8123, max = 8149 }
+proxy_port = 8100

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -17,6 +17,10 @@ ignore = [
 exclude = ["debug/*"]
 
 [lint.per-file-ignores]
+"scripts/*" = [
+    "INP001",  # standalone scripts, not a package
+    "T201",    # scripts print their output
+]
 "tests/*" = [
     "S101", # Use of assert detected (tests need assert)
     "S106", # Possible hardcoded password in tests (test data is fine)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,14 +13,15 @@ This is a Home Assistant custom integration for Orbit B-hyve irrigation devices.
 - `pip install -r requirements.txt` - Install Python dependencies
 
 ### Development
-- `./scripts/bootstrap` - Create a shared host venv at `~/.venvs/bhyve` with uv (no dev container needed)
+- `./scripts/bootstrap` - Create `./.venv` with uv (no dev container needed)
 - `./scripts/develop` - Run Home Assistant in development mode with this integration loaded
-- `HA_PORT=8124 ./scripts/develop` - Run on another port so two worktrees can run at once
+- `portree up` - Run Home Assistant on a port portree picks for this worktree; `portree ls --json` gives the `direct_url`
+- `HA_PORT=8124 ./scripts/develop` - Run on a fixed port by hand
 - `./scripts/develop --watch` - Restart Home Assistant when files under `custom_components/` change
-- `./scripts/worktree <branch>` - Create a sibling git worktree seeded with this checkout's HA state and a free port
+- `./scripts/worktree <branch>` - Create a sibling git worktree that shares this `.venv`, seeded with this checkout's HA state
 - `./scripts/lint` - Format and lint code using ruff
 
-Scripts pick the Python from `./.venv`, then `$BHYVE_VENV`, then `~/.venvs/bhyve`, then `PATH`.
+Scripts use `./.venv` when it exists, otherwise whatever is on `PATH`. Everything lives inside the repo; only uv's wheel cache is in `~/.cache/uv`.
 
 ### Testing
 - `./scripts/test` - Run all tests with verbose output

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,14 @@ This is a Home Assistant custom integration for Orbit B-hyve irrigation devices.
 - `pip install -r requirements.txt` - Install Python dependencies
 
 ### Development
+- `./scripts/bootstrap` - Create a shared host venv at `~/.venvs/bhyve` with uv (no dev container needed)
 - `./scripts/develop` - Run Home Assistant in development mode with this integration loaded
+- `HA_PORT=8124 ./scripts/develop` - Run on another port so two worktrees can run at once
+- `./scripts/develop --watch` - Restart Home Assistant when files under `custom_components/` change
+- `./scripts/worktree <branch>` - Create a sibling git worktree seeded with this checkout's HA state and a free port
 - `./scripts/lint` - Format and lint code using ruff
+
+Scripts pick the Python from `./.venv`, then `$BHYVE_VENV`, then `~/.venvs/bhyve`, then `PATH`.
 
 ### Testing
 - `./scripts/test` - Run all tests with verbose output

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -1,10 +1,20 @@
+# Development configuration. A trimmed set of integrations replaces
+# `default_config:` so Home Assistant starts in seconds.
 
-# Loads default set of integrations. Do not remove.
-default_config:
+homeassistant:
+  name: B-hyve Dev
 
-# Load frontend themes from the themes folder
+http:
+  server_port: !env_var HA_PORT 8123
+
 frontend:
   themes: !include_dir_merge_named themes
+config:
+api:
+history:
+logbook:
+recorder:
+  commit_interval: 30
 
 automation: !include automations.yaml
 script: !include scripts.yaml

--- a/scripts/_ha_requirements.py
+++ b/scripts/_ha_requirements.py
@@ -1,0 +1,41 @@
+"""
+Print the pip requirements of the Home Assistant integrations used by config/.
+
+Walks the dependency closure of the domains named in configuration.yaml
+(plus the ones Home Assistant always loads) so they can be installed into
+the venv up front. That lets scripts/develop pass --skip-pip and boot fast.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+from homeassistant import components
+
+COMPONENTS = Path(components.__file__).parent
+CORE_DOMAINS = {
+    "homeassistant",
+    "persistent_notification",
+    "backup",
+    "frontend",
+    "http",
+}
+DOMAINS = set(sys.argv[1:]) | CORE_DOMAINS
+
+seen: set[str] = set()
+requirements: set[str] = set()
+queue = list(DOMAINS)
+while queue:
+    domain = queue.pop()
+    if domain in seen:
+        continue
+    seen.add(domain)
+    manifest = COMPONENTS / domain / "manifest.json"
+    if not manifest.exists():
+        continue
+    data = json.loads(manifest.read_text())
+    requirements.update(data.get("requirements", []))
+    queue.extend(data.get("dependencies", []))
+    queue.extend(data.get("after_dependencies", []))
+
+print("\n".join(sorted(requirements)))

--- a/scripts/_venv
+++ b/scripts/_venv
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Sourced by the other scripts. Puts the right Python on PATH.
+#
+# Order of preference:
+#   1. ./.venv                  a venv local to this worktree
+#   2. $BHYVE_VENV              an explicit override
+#   3. ~/.venvs/bhyve           the shared venv created by scripts/bootstrap
+#   4. whatever is already on PATH (the dev container)
+
+_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+for _candidate in "${_root}/.venv" "${BHYVE_VENV:-}" "${HOME}/.venvs/bhyve"; do
+    if [[ -n "${_candidate}" && -x "${_candidate}/bin/python" ]]; then
+        export VIRTUAL_ENV="${_candidate}"
+        export PATH="${_candidate}/bin:${PATH}"
+        break
+    fi
+done
+
+unset _root _candidate

--- a/scripts/_venv
+++ b/scripts/_venv
@@ -1,20 +1,12 @@
 #!/usr/bin/env bash
-# Sourced by the other scripts. Puts the right Python on PATH.
-#
-# Order of preference:
-#   1. ./.venv                  a venv local to this worktree
-#   2. $BHYVE_VENV              an explicit override
-#   3. ~/.venvs/bhyve           the shared venv created by scripts/bootstrap
-#   4. whatever is already on PATH (the dev container)
+# Sourced by the other scripts. Puts ./.venv on PATH if it exists,
+# otherwise leaves PATH alone (the dev container already has hass installed).
 
 _root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-for _candidate in "${_root}/.venv" "${BHYVE_VENV:-}" "${HOME}/.venvs/bhyve"; do
-    if [[ -n "${_candidate}" && -x "${_candidate}/bin/python" ]]; then
-        export VIRTUAL_ENV="${_candidate}"
-        export PATH="${_candidate}/bin:${PATH}"
-        break
-    fi
-done
+if [[ -x "${_root}/.venv/bin/python" ]]; then
+    export VIRTUAL_ENV="${_root}/.venv"
+    export PATH="${_root}/.venv/bin:${PATH}"
+fi
 
-unset _root _candidate
+unset _root

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Create (or refresh) a Python environment on the host without a dev container.
+#
+#   scripts/bootstrap            shared venv at ~/.venvs/bhyve, used by every worktree
+#   scripts/bootstrap --local    venv at ./.venv, for a branch that changes requirements.txt
+#
+# Needs uv: https://docs.astral.sh/uv/  (brew install uv)
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+PYTHON_VERSION="3.13"
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "uv is required: brew install uv" >&2
+    exit 1
+fi
+
+if [[ "${1:-}" == "--local" ]]; then
+    venv="${PWD}/.venv"
+else
+    venv="${BHYVE_VENV:-${HOME}/.venvs/bhyve}"
+fi
+
+if [[ ! -x "${venv}/bin/python" ]]; then
+    uv venv "${venv}" --python "${PYTHON_VERSION}"
+fi
+
+uv pip install --python "${venv}/bin/python" --requirement requirements.txt
+
+# Install what the integrations in config/configuration.yaml need, so that
+# scripts/develop can boot with --skip-pip instead of resolving them each start.
+domains="$(grep -oE '^[a-z_]+:' config/configuration.yaml | tr -d ':' | tr '\n' ' ')"
+"${venv}/bin/python" scripts/_ha_requirements.py ${domains} \
+    | uv pip install --python "${venv}/bin/python" --requirement -
+
+echo
+echo "Ready: ${venv}"
+echo "scripts/develop and scripts/test will pick it up automatically."

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 #
-# Create (or refresh) a Python environment on the host without a dev container.
+# Create (or refresh) ./.venv so the repo runs on the host without a dev container.
 #
-#   scripts/bootstrap            shared venv at ~/.venvs/bhyve, used by every worktree
-#   scripts/bootstrap --local    venv at ./.venv, for a branch that changes requirements.txt
+# Worktrees made by scripts/worktree symlink .venv to the main checkout's venv.
+# Running this inside such a worktree replaces the symlink with a venv of its
+# own, for branches that change requirements.txt.
 #
 # Needs uv: https://docs.astral.sh/uv/  (brew install uv)
 
@@ -12,16 +13,16 @@ set -e
 cd "$(dirname "$0")/.."
 
 PYTHON_VERSION="3.13"
+venv="${PWD}/.venv"
 
 if ! command -v uv >/dev/null 2>&1; then
     echo "uv is required: brew install uv" >&2
     exit 1
 fi
 
-if [[ "${1:-}" == "--local" ]]; then
-    venv="${PWD}/.venv"
-else
-    venv="${BHYVE_VENV:-${HOME}/.venvs/bhyve}"
+if [[ -L "${venv}" ]]; then
+    echo "Replacing shared venv symlink with a venv local to this worktree"
+    rm "${venv}"
 fi
 
 if [[ ! -x "${venv}/bin/python" ]]; then
@@ -38,4 +39,3 @@ domains="$(grep -oE '^[a-z_]+:' config/configuration.yaml | tr -d ':' | tr '\n' 
 
 echo
 echo "Ready: ${venv}"
-echo "scripts/develop and scripts/test will pick it up automatically."

--- a/scripts/develop
+++ b/scripts/develop
@@ -3,7 +3,8 @@
 # Run Home Assistant with this worktree's integration loaded.
 #
 #   scripts/develop                 listen on 8123
-#   HA_PORT=8124 scripts/develop    listen on another port (second worktree)
+#   HA_PORT=8124 scripts/develop    listen on another port
+#   portree up                      let portree pick the port (it sets $PORT)
 #   scripts/develop --watch         restart on any change under custom_components (needs watchexec)
 
 set -e
@@ -30,7 +31,7 @@ fi
 ## while at the same time have Home Assistant configuration inside <root>/config
 ## without resulting to symlinks.
 export PYTHONPATH="${PYTHONPATH}:${PWD}/custom_components"
-export HA_PORT="${HA_PORT:-8123}"
+export HA_PORT="${HA_PORT:-${PORT:-8123}}"
 
 echo "Home Assistant on http://localhost:${HA_PORT}"
 

--- a/scripts/develop
+++ b/scripts/develop
@@ -1,8 +1,23 @@
 #!/usr/bin/env bash
+#
+# Run Home Assistant with this worktree's integration loaded.
+#
+#   scripts/develop                 listen on 8123
+#   HA_PORT=8124 scripts/develop    listen on another port (second worktree)
+#   scripts/develop --watch         restart on any change under custom_components (needs watchexec)
 
 set -e
 
 cd "$(dirname "$0")/.."
+source scripts/_venv
+
+if [[ "${1:-}" == "--watch" ]]; then
+    if ! command -v watchexec >/dev/null 2>&1; then
+        echo "watchexec is required for --watch: brew install watchexec" >&2
+        exit 1
+    fi
+    exec watchexec --restart --exts py,json --watch custom_components -- "$0"
+fi
 
 # Create config dir if not present
 if [[ ! -d "${PWD}/config" ]]; then
@@ -15,6 +30,9 @@ fi
 ## while at the same time have Home Assistant configuration inside <root>/config
 ## without resulting to symlinks.
 export PYTHONPATH="${PYTHONPATH}:${PWD}/custom_components"
+export HA_PORT="${HA_PORT:-8123}"
 
-# Start Home Assistant
-hass --config "${PWD}/config" --debug
+echo "Home Assistant on http://localhost:${HA_PORT}"
+
+# --skip-pip: the integration has no requirements, so skip pip on every boot.
+hass --config "${PWD}/config" --debug --skip-pip

--- a/scripts/lint
+++ b/scripts/lint
@@ -3,6 +3,7 @@
 set -e
 
 cd "$(dirname "$0")/.."
+source scripts/_venv
 
 ruff format .
 ruff check . --fix

--- a/scripts/test
+++ b/scripts/test
@@ -3,9 +3,10 @@
 set -e
 
 cd "$(dirname "$0")/.."
+source scripts/_venv
 
 # Run tests with verbose output and coverage
-python -m pytest tests/ -v --tb=short
+python -m pytest tests/ -v --tb=short "$@"
 
 # Optional: Run with coverage if pytest-cov is available
 # python -m pytest tests/ -v --cov=custom_components.bhyve --cov-report=term-missing

--- a/scripts/worktree
+++ b/scripts/worktree
@@ -8,7 +8,8 @@
 #   scripts/worktree existing-branch         checks out a branch that already exists
 #
 # Worktrees are created as siblings of this repo: ../<repo>-<branch>.
-# Each gets the next free port starting at 8124.
+# Each shares this checkout's .venv through a symlink; run scripts/bootstrap
+# inside the worktree if the branch needs its own. Ports come from portree.
 
 set -e
 
@@ -40,21 +41,14 @@ if [[ -d config/.storage ]]; then
     [[ -f config/.HA_VERSION ]] && cp config/.HA_VERSION "${dir}/config/"
 fi
 
-# Pick the first port from 8124 upwards that nothing is listening on.
-port=8124
-while lsof -iTCP:"${port}" -sTCP:LISTEN >/dev/null 2>&1; do
-    port=$((port + 1))
-done
-
-# Leave a per-worktree env file that direnv or the shell can source.
-cat > "${dir}/.env.local" <<ENV
-export HA_PORT=${port}
-ENV
+# Share this checkout's venv. scripts/bootstrap in the worktree replaces it.
+if [[ -x .venv/bin/python ]]; then
+    ln -s "${PWD}/.venv" "${dir}/.venv"
+fi
 
 echo
 echo "Worktree: ${dir}"
 echo "Branch:   ${branch}"
-echo "Port:     ${port}"
 echo
 echo "  cd ${dir}"
-echo "  source .env.local && scripts/develop"
+echo "  portree up && portree ls"

--- a/scripts/worktree
+++ b/scripts/worktree
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Create a git worktree for a branch and seed it with this checkout's Home
+# Assistant state, so you can run it straight away without onboarding again.
+#
+#   scripts/worktree my-feature              new branch off HEAD
+#   scripts/worktree my-feature origin/main  new branch off a given start point
+#   scripts/worktree existing-branch         checks out a branch that already exists
+#
+# Worktrees are created as siblings of this repo: ../<repo>-<branch>.
+# Each gets the next free port starting at 8124.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+branch="${1:?usage: scripts/worktree <branch> [start-point]}"
+start="${2:-HEAD}"
+
+repo_name="$(basename "${PWD}")"
+dir="$(dirname "${PWD}")/${repo_name}-${branch//\//-}"
+
+if [[ -e "${dir}" ]]; then
+    echo "${dir} already exists" >&2
+    exit 1
+fi
+
+if git show-ref --verify --quiet "refs/heads/${branch}"; then
+    git worktree add "${dir}" "${branch}"
+else
+    git worktree add -b "${branch}" "${dir}" "${start}"
+fi
+
+# Seed HA state. .storage holds auth, onboarding and the bhyve config entry.
+# The recorder database and logs are left behind on purpose.
+if [[ -d config/.storage ]]; then
+    mkdir -p "${dir}/config"
+    cp -R config/.storage "${dir}/config/.storage"
+    rm -f "${dir}/config/.storage/core.restore_state"
+    [[ -f config/.HA_VERSION ]] && cp config/.HA_VERSION "${dir}/config/"
+fi
+
+# Pick the first port from 8124 upwards that nothing is listening on.
+port=8124
+while lsof -iTCP:"${port}" -sTCP:LISTEN >/dev/null 2>&1; do
+    port=$((port + 1))
+done
+
+# Leave a per-worktree env file that direnv or the shell can source.
+cat > "${dir}/.env.local" <<ENV
+export HA_PORT=${port}
+ENV
+
+echo
+echo "Worktree: ${dir}"
+echo "Branch:   ${branch}"
+echo "Port:     ${port}"
+echo
+echo "  cd ${dir}"
+echo "  source .env.local && scripts/develop"


### PR DESCRIPTION
## What changed

The integration is plain Python loaded through `PYTHONPATH`, so the environment does not depend on the branch. This adds scripts for a host venv so several worktrees can run at once without building a dev container for each. Everything stays inside the repo; only uv's wheel cache is in `~/.cache/uv`.

- `scripts/bootstrap` creates `./.venv` with uv. It also installs the requirements of the integrations the dev config loads, so Home Assistant can boot with `--skip-pip`.
- `scripts/_venv` puts `./.venv` on `PATH` for the other scripts when it exists. The dev container still works unchanged.
- `scripts/develop` reads `HA_PORT`, or the `PORT` portree sets, passes `--skip-pip`, and gains `--watch` to restart on file changes via watchexec.
- `scripts/worktree <branch>` creates a sibling worktree, symlinks `.venv` to this checkout's, and copies `config/.storage` so auth and the bhyve config entry carry over. Running `scripts/bootstrap` inside the worktree swaps the symlink for a venv of its own.
- `.portree.toml` defines a `hass` service so `portree up` runs each worktree on its own port with a `<branch>.localhost:8100` proxy.
- `config/configuration.yaml` replaces `default_config` with the few integrations needed.

## Why

Each worktree used to need its own dev container build. Now a new worktree is ready in seconds and Home Assistant boots in about three seconds instead of tens.

## Checked

- `scripts/bootstrap` on macOS with uv and Python 3.13; a rebuild from cache takes 4s
- `scripts/test`: 165 passed, 5 skipped
- `scripts/lint`: clean
- `portree up` in the main checkout and in a fresh `scripts/worktree`: HA initialised in 3.5s, bhyve loaded, both `direct_url` and proxy URL answer 200