### PR TITLE
Install the base component requirements in bootstrap

### DIFF
--- a/scripts/_ha_requirements.py
+++ b/scripts/_ha_requirements.py
@@ -20,7 +20,30 @@ CORE_DOMAINS = {
     "frontend",
     "http",
 }
-DOMAINS = set(sys.argv[1:]) | CORE_DOMAINS
+# homeassistant.helpers.service imports these whenever a services.yaml uses
+# `supported_features`, so their requirements must be present too.
+BASE_COMPONENTS = {
+    "ai_task",
+    "alarm_control_panel",
+    "assist_satellite",
+    "calendar",
+    "camera",
+    "climate",
+    "cover",
+    "fan",
+    "humidifier",
+    "light",
+    "lock",
+    "media_player",
+    "notify",
+    "remote",
+    "siren",
+    "todo",
+    "update",
+    "vacuum",
+    "water_heater",
+}
+DOMAINS = set(sys.argv[1:]) | CORE_DOMAINS | BASE_COMPONENTS
 
 seen: set[str] = set()
 requirements: set[str] = set()

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -8,7 +8,7 @@
 #
 # Needs uv: https://docs.astral.sh/uv/  (brew install uv)
 
-set -e
+set -eo pipefail
 
 cd "$(dirname "$0")/.."
 


### PR DESCRIPTION
Home Assistant's service helper imports a fixed set of base components whenever a `services.yaml` uses `supported_features`. One of them, `conversation`, needs `hassil`, which bootstrap did not install, so the bhyve service descriptions failed to load under `--skip-pip`.

The resolver now includes that set. `bootstrap` also sets `pipefail` so a resolver failure stops the script instead of being hidden by the pipe.

Checked: `scripts/bootstrap` installs hassil and friends, HA boots clean in 2.8s via `portree up`, lint passes.