### PR TITLE
Link child devices to their bridge with via_device_id

### DIFF
--- a/custom_components/bhyve/__init__.py
+++ b/custom_components/bhyve/__init__.py
@@ -38,6 +38,10 @@ from .util import filter_configured_devices
 
 _LOGGER = logging.getLogger(__name__)
 
+# Home Assistant 2026.8 added `via_device_id` to DeviceInfo and deprecated
+# `via_device`, which stops working in 2027.8. Older releases reject the new key.
+VIA_DEVICE_ID_SUPPORTED = "via_device_id" in DeviceInfo.__optional_keys__
+
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.SELECT,
@@ -101,18 +105,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         str(d["id"]) for d in all_devices if d.get("type") != DEVICE_BRIDGE
     }
     if removed_device_ids := leaf_device_ids - configured_ids:
-        await remove_devices_from_registry(hass, removed_device_ids)
+        await remove_devices_from_registry(hass, entry.entry_id, removed_device_ids)
 
-    # Build a mapping from device_gateway_topic to bridge device ID
-    # so child devices can reference their bridge via via_device.
+    # Register bridges before any platform loads, so child devices can point at
+    # a bridge that already exists in the device registry. Record each bridge's
+    # gateway topic and registry id for the entities to look up.
     # Bridges are always included by filter_configured_devices.
+    device_registry = dr.async_get(hass)
     gateway_to_bridge: dict[str, str] = {}
+    bridge_device_ids: dict[str, str] = {}
     for device in devices:
-        if device.get("type") == DEVICE_BRIDGE:
-            gateway_topic = device.get("device_gateway_topic")
-            if gateway_topic:
-                gateway_to_bridge[gateway_topic] = device.get("id", "")
+        if device.get("type") != DEVICE_BRIDGE:
+            continue
+        bridge_id = device.get("id")
+        if not bridge_id:
+            continue
+        bridge_entry = device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id, **build_device_info(device)
+        )
+        bridge_device_ids[bridge_id] = bridge_entry.id
+        if gateway_topic := device.get("device_gateway_topic"):
+            gateway_to_bridge[gateway_topic] = bridge_id
     coordinator.gateway_to_bridge = gateway_to_bridge
+    coordinator.bridge_device_ids = bridge_device_ids
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         "client": client,
@@ -129,20 +144,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def remove_devices_from_registry(
-    hass: HomeAssistant, device_ids: set[str]
+    hass: HomeAssistant, entry_id: str, device_ids: set[str]
 ) -> None:
-    """Remove devices from registry by domain-specific string identifiers."""
+    """Remove this entry's devices from the registry by their B-hyve ids."""
     device_registry = dr.async_get(hass)
+    identifiers = {(DOMAIN, device_id) for device_id in device_ids}
 
-    for device_id in device_ids:
-        # Find the device in the registry by its identifiers
-        device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
-        if device:
-            _LOGGER.info("Removing device %s from registry", device_id)
-            try:
-                device_registry.async_remove_device(device.id)
-            except HomeAssistantError:
-                _LOGGER.exception("Failed to remove device %s from registry", device_id)
+    for device in dr.async_entries_for_config_entry(device_registry, entry_id):
+        if device.identifiers.isdisjoint(identifiers):
+            continue
+        _LOGGER.info("Removing device %s from registry", device.identifiers)
+        try:
+            device_registry.async_remove_device(device.id)
+        except HomeAssistantError:
+            _LOGGER.exception("Failed to remove device %s from registry", device.id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -157,6 +172,28 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+
+def build_device_info(device: BHyveDevice) -> DeviceInfo:
+    """Describe a B-hyve device for the device registry."""
+    device_id = device.get("id", "")
+    connections: set[tuple[str, str]] = set()
+    if mac_address := device.get("mac_address"):
+        # Format raw MAC (e.g. "4467552a366e") with colons
+        raw = mac_address.replace(":", "").replace("-", "").lower()
+        formatted_mac = ":".join(raw[i : i + 2] for i in range(0, len(raw), 2))
+        connections.add((CONNECTION_NETWORK_MAC, formatted_mac))
+
+    return DeviceInfo(
+        identifiers={(DOMAIN, device_id)},
+        connections=connections,
+        manufacturer=MANUFACTURER,
+        configuration_url=f"https://techsupport.orbitbhyve.com/dashboard/support/device/{device_id}",
+        name=device.get("name", ""),
+        model=device.get("hardware_version"),
+        hw_version=device.get("hardware_version"),
+        sw_version=device.get("firmware_version"),
+    )
 
 
 class BHyveCoordinatorEntity(CoordinatorEntity[BHyveDataUpdateCoordinator]):
@@ -174,31 +211,19 @@ class BHyveCoordinatorEntity(CoordinatorEntity[BHyveDataUpdateCoordinator]):
         self._device_name = device.get("name", "")
         self._mac_address = device.get("mac_address")
 
-        # Device info for grouping
-        connections: set[tuple[str, str]] = set()
-        if self._mac_address:
-            # Format raw MAC (e.g. "4467552a366e") with colons
-            raw = self._mac_address.replace(":", "").replace("-", "").lower()
-            formatted_mac = ":".join(raw[i : i + 2] for i in range(0, len(raw), 2))
-            connections.add((CONNECTION_NETWORK_MAC, formatted_mac))
-
-        device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._device_id)},
-            connections=connections,
-            manufacturer=MANUFACTURER,
-            configuration_url=f"https://techsupport.orbitbhyve.com/dashboard/support/device/{self._device_id}",
-            name=self._device_name,
-            model=device.get("hardware_version"),
-            hw_version=device.get("hardware_version"),
-            sw_version=device.get("firmware_version"),
-        )
+        device_info = build_device_info(device)
 
         # Link non-bridge devices to their bridge via device_gateway_topic
         if self._device_type != DEVICE_BRIDGE:
             gateway_topic = device.get("device_gateway_topic")
             gateway_to_bridge = getattr(coordinator, "gateway_to_bridge", {})
             bridge_id = gateway_to_bridge.get(gateway_topic) if gateway_topic else None
-            if bridge_id:
+            if bridge_id and VIA_DEVICE_ID_SUPPORTED:
+                # async_setup_entry registered the bridge, so its id is known.
+                bridge_device_ids = getattr(coordinator, "bridge_device_ids", {})
+                if bridge_entry_id := bridge_device_ids.get(bridge_id):
+                    device_info["via_device_id"] = bridge_entry_id
+            elif bridge_id:
                 device_info["via_device"] = (DOMAIN, bridge_id)
 
         self._attr_device_info = device_info

--- a/custom_components/bhyve/coordinator.py
+++ b/custom_components/bhyve/coordinator.py
@@ -53,7 +53,10 @@ class BHyveDataUpdateCoordinator(DataUpdateCoordinator):
         )
         self.client = client
         self.entry = entry
+        # device_gateway_topic -> B-hyve id of the bridge serving it
         self.gateway_to_bridge: dict[str, str] = {}
+        # B-hyve id of a bridge -> its device registry id
+        self.bridge_device_ids: dict[str, str] = {}
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from API (periodic polling)."""

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,6 +1,6 @@
 """Test BHyve binary sensor entities."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
@@ -889,40 +889,71 @@ class TestBHyveBridgeConnectivitySensor:
 
 
 class TestBridgeViaDevice:
-    """Test that child devices reference their bridge via via_device."""
+    """Test that child devices link to their bridge."""
 
-    async def test_child_device_has_via_device(self) -> None:
-        """Test that a flood sensor references its bridge."""
-        flood_device = BHyveDevice(
-            {
-                "id": "test-flood-123",
-                "name": "Basement Flood",
-                "type": "flood_sensor",
-                "mac_address": "aa:bb:cc:dd:ee:ff",
-                "is_connected": True,
-                "device_gateway_topic": "devices-1",
-            }
+    @staticmethod
+    def _flood_sensor(
+        coordinator: MagicMock, gateway_topic: str | None
+    ) -> BHyveBinarySensor:
+        device = {
+            "id": "test-flood-123",
+            "name": "Basement Flood",
+            "type": "flood_sensor",
+            "mac_address": "aa:bb:cc:dd:ee:ff",
+            "is_connected": True,
+        }
+        if gateway_topic:
+            device["device_gateway_topic"] = gateway_topic
+        flood_device = BHyveDevice(device)
+        coordinator.data["devices"]["test-flood-123"] = {
+            "device": flood_device,
+            "history": [],
+            "landscapes": {},
+        }
+        return BHyveBinarySensor(
+            coordinator=coordinator,
+            device=flood_device,
+            description=BINARY_SENSOR_TYPES[0],
         )
-        coordinator = create_mock_coordinator(
-            {
-                "test-flood-123": {
-                    "device": flood_device,
-                    "history": [],
-                    "landscapes": {},
-                }
-            }
-        )
+
+    async def test_child_device_links_by_registry_id(self) -> None:
+        """A flood sensor points at the bridge's device registry id."""
+        coordinator = create_mock_coordinator({})
         coordinator.gateway_to_bridge = {"devices-1": "bridge-id-123"}
+        coordinator.bridge_device_ids = {"bridge-id-123": "registry-id-abc"}
 
-        description = BINARY_SENSOR_TYPES[0]
-        sensor = BHyveBinarySensor(
-            coordinator=coordinator, device=flood_device, description=description
-        )
+        with patch("custom_components.bhyve.VIA_DEVICE_ID_SUPPORTED", new=True):
+            sensor = self._flood_sensor(coordinator, "devices-1")
+
+        assert sensor.device_info["via_device_id"] == "registry-id-abc"
+        assert "via_device" not in sensor.device_info
+
+    async def test_child_device_links_by_identifier_on_old_ha(self) -> None:
+        """Before HA 2026.8 the link uses the deprecated via_device identifier."""
+        coordinator = create_mock_coordinator({})
+        coordinator.gateway_to_bridge = {"devices-1": "bridge-id-123"}
+        coordinator.bridge_device_ids = {"bridge-id-123": "registry-id-abc"}
+
+        with patch("custom_components.bhyve.VIA_DEVICE_ID_SUPPORTED", new=False):
+            sensor = self._flood_sensor(coordinator, "devices-1")
 
         assert sensor.device_info["via_device"] == ("bhyve", "bridge-id-123")
+        assert "via_device_id" not in sensor.device_info
+
+    async def test_child_device_with_unregistered_bridge_has_no_link(self) -> None:
+        """No link is set when the bridge is missing from the registry."""
+        coordinator = create_mock_coordinator({})
+        coordinator.gateway_to_bridge = {"devices-1": "bridge-id-123"}
+        coordinator.bridge_device_ids = {}
+
+        with patch("custom_components.bhyve.VIA_DEVICE_ID_SUPPORTED", new=True):
+            sensor = self._flood_sensor(coordinator, "devices-1")
+
+        assert "via_device_id" not in sensor.device_info
+        assert "via_device" not in sensor.device_info
 
     async def test_bridge_device_has_no_via_device(self) -> None:
-        """Test that a bridge device does not have via_device."""
+        """A bridge device does not link to itself."""
         bridge_device = BHyveDevice(
             {
                 "id": "test-bridge-123",
@@ -943,6 +974,7 @@ class TestBridgeViaDevice:
             }
         )
         coordinator.gateway_to_bridge = {"devices-1": "test-bridge-123"}
+        coordinator.bridge_device_ids = {"test-bridge-123": "registry-id-abc"}
 
         description = BINARY_SENSOR_TYPES[3]
         sensor = BHyveBinarySensor(
@@ -950,31 +982,13 @@ class TestBridgeViaDevice:
         )
 
         assert "via_device" not in sensor.device_info
+        assert "via_device_id" not in sensor.device_info
 
     async def test_child_device_without_gateway_has_no_via_device(self) -> None:
-        """Test that a device without gateway_topic has no via_device."""
-        flood_device = BHyveDevice(
-            {
-                "id": "test-flood-123",
-                "name": "Basement Flood",
-                "type": "flood_sensor",
-                "mac_address": "aa:bb:cc:dd:ee:ff",
-                "is_connected": True,
-            }
-        )
-        coordinator = create_mock_coordinator(
-            {
-                "test-flood-123": {
-                    "device": flood_device,
-                    "history": [],
-                    "landscapes": {},
-                }
-            }
-        )
+        """A device without a gateway topic has no link."""
+        coordinator = create_mock_coordinator({})
 
-        description = BINARY_SENSOR_TYPES[0]
-        sensor = BHyveBinarySensor(
-            coordinator=coordinator, device=flood_device, description=description
-        )
+        sensor = self._flood_sensor(coordinator, None)
 
         assert "via_device" not in sensor.device_info
+        assert "via_device_id" not in sensor.device_info

--- a/tests/test_device_removal.py
+++ b/tests/test_device_removal.py
@@ -55,7 +55,7 @@ async def test_remove_devices_from_registry(hass: HomeAssistant) -> None:
     assert device_registry.async_get(device3.id) is not None
 
     # Remove device1 and device3
-    await remove_devices_from_registry(hass, {"device1", "device3"})
+    await remove_devices_from_registry(hass, "test_entry", {"device1", "device3"})
 
     # Verify device1 and device3 are removed, device2 remains
     assert device_registry.async_get(device1.id) is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,92 @@
+"""Test integration setup."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+import pytest
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers import device_registry as dr
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bhyve.const import CONF_DEVICES, DOMAIN
+
+if TYPE_CHECKING:
+    from asyncio import AbstractEventLoop
+    from collections.abc import Callable
+
+    from homeassistant.core import HomeAssistant
+
+BRIDGE = {
+    "id": "bridge-1",
+    "name": "Wi-Fi Hub",
+    "type": "bridge",
+    "mac_address": "446755dc6001",
+    "is_connected": True,
+    "device_gateway_topic": "devices-1",
+}
+FLOOD = {
+    "id": "flood-1",
+    "name": "Basement Flood",
+    "type": "flood_sensor",
+    "is_connected": True,
+    "device_gateway_topic": "devices-1",
+    "status": {},
+}
+
+
+class FakeClient:
+    """Stand-in for BHyveClient that serves canned devices."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Accept and ignore the real client's arguments."""
+
+    async def login(self) -> bool:
+        """Report a successful login."""
+        return True
+
+    def listen(self, loop: AbstractEventLoop, async_callback: Callable) -> None:
+        """Do not open a websocket."""
+
+    async def stop(self, *args: Any, **kwargs: Any) -> None:
+        """Nothing to stop."""
+
+    @property
+    async def devices(self) -> list[dict[str, Any]]:
+        """Return a bridge and a flood sensor behind it."""
+        return [dict(BRIDGE), dict(FLOOD)]
+
+    @property
+    async def timer_programs(self) -> list[dict[str, Any]]:
+        """Return no programs."""
+        return []
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_setup_links_child_devices_to_bridge(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Child devices link to the bridge's registry entry by id."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "user", CONF_PASSWORD: "password"},
+        options={CONF_DEVICES: ["flood-1"]},
+    )
+    entry.add_to_hass(hass)
+
+    with patch("custom_components.bhyve.BHyveClient", FakeClient):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    device_registry = dr.async_get(hass)
+    by_identifier = {
+        identifier: device
+        for device in dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+        for identifier in device.identifiers
+    }
+    bridge = by_identifier[(DOMAIN, "bridge-1")]
+    flood = by_identifier[(DOMAIN, "flood-1")]
+    assert bridge.via_device_id is None
+    assert flood.via_device_id == bridge.id
+    assert "deprecated `via_device`" not in caplog.text


### PR DESCRIPTION
Fixes #480.

## What changed

Home Assistant 2026.8 deprecated the `via_device` field in `DeviceInfo` and logs a warning for every platform that uses it. It stops working in 2027.8. The replacement, `via_device_id`, takes the bridge's device registry id, so the bridge has to exist before its children.

- `async_setup_entry` registers each bridge in the device registry before platforms load and keeps a map from B-hyve bridge id to registry id on the coordinator.
- Entities read that map to set `via_device_id`. Home Assistant releases before 2026.8 reject the new key, so those still get `via_device`. The check is a module constant.
- The device info block moved out of the entity into `build_device_info` so the up-front bridge registration and the entities describe a device the same way.
- `remove_devices_from_registry` no longer calls `async_get_device`, which 2026.8 also deprecated with the same 2027.8 cutoff. It now scans the config entry's devices and matches on identifiers.

## Tests

- Unit tests cover both code paths by patching the version check.
- `tests/test_init.py` runs a full setup with a fake client. Before this change it reproduced the warnings from the issue. Now it asserts the flood sensor's `via_device_id` equals the bridge's registry id and that no deprecation warning is logged.
- Suite passes on HA 2025.12 (the pinned version) and on HA 2026.9.0 with Python 3.14: 168 passed, 5 skipped each.
- Booted HA 2026.9 against a real account: no frame warnings, and the registry shows the timers linked via the Wi-Fi Hub.

`requirements.txt` stays at 2025.12 because 2026.9 needs Python 3.14, which `scripts/bootstrap` does not set up yet.
