### PR TITLE
feat: add smart watering zone sensor

### DIFF
--- a/custom_components/bhyve/sensor.py
+++ b/custom_components/bhyve/sensor.py
@@ -668,7 +668,9 @@ class BHyveSmartWateringZoneSensor(BHyveCoordinatorEntity, SensorEntity):
 
         current_moisture_balance: float | None
         if now < nine_am:
-            current_moisture_balance = initial_moisture_balance
+            current_moisture_balance = (
+                initial_moisture_balance + effective_rainfall + effective_irrigation
+            )
         elif now < nine_pm:
             daylight_hours_elapsed = (now - nine_am).total_seconds() / 3600
             total_daylight_hours = 12

--- a/custom_components/bhyve/sensor.py
+++ b/custom_components/bhyve/sensor.py
@@ -660,9 +660,7 @@ class BHyveSmartWateringZoneSensor(BHyveCoordinatorEntity, SensorEntity):
         ):
             return None
 
-        local_tz = dt.get_default_time_zone()
-
-        now = datetime.now(local_tz)
+        now = self._get_local_datetime()
 
         nine_am = now.replace(hour=9, minute=0, second=0, microsecond=0)
 
@@ -687,6 +685,11 @@ class BHyveSmartWateringZoneSensor(BHyveCoordinatorEntity, SensorEntity):
             current_moisture_balance = zone_forcast.get("final_water_level")
 
         return current_moisture_balance
+
+    def _get_local_datetime(self) -> datetime:
+        """Return current datetime in the local timezone."""
+        local_tz = dt.get_default_time_zone()
+        return datetime.now(local_tz)
 
     def _get_landscape(self) -> dict | None:
         """Return the landscape entry for this zone."""

--- a/custom_components/bhyve/sensor.py
+++ b/custom_components/bhyve/sensor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
@@ -16,6 +17,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.helpers.icon import icon_for_battery_level
+from homeassistant.util import dt
 
 from . import BHyveCoordinatorEntity
 from .const import (
@@ -26,8 +28,6 @@ from .const import (
 from .util import orbit_time_to_local_time
 
 if TYPE_CHECKING:
-    from datetime import datetime
-
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -47,6 +47,38 @@ ATTR_RUN_TIME = "run_time"
 ATTR_NEXT_START_PROGRAMS = "programs"
 ATTR_START_TIME = "start_time"
 ATTR_STATUS = "status"
+
+# landscape attrs (editable)
+ATTR_APPLICATION_RATE = "application_rate"
+ATTR_EFFICIENCY = "efficiency"
+ATTR_PLANT_FACTOR = "plant_factor"
+ATTR_MICROCLIMATE_FACTOR = "micro_climate"
+ATTR_MGMT_ALLOWED_DEPLETION = "max_allowable_depletion"
+ATTR_FIELD_CAPACITY = "field_capacity"
+ATTR_PERMANENT_WILTING_POINT = "permanent_wilting_point"
+ATTR_ROOT_ZONE = "root_depth"
+ATTR_ALLOWABLE_SURFACE_ACCUMULATION = "allowable_soil_acc"
+ATTR_BASIC_INFILTRATION_RATE = "infiltration_rate"
+ATTR_EFFECTIVE_RAINFALL = "rainfall_efficiency"
+ATTR_DROUGHT_FACTOR = "drought_factor"
+
+# landscape attrs (computed)
+ATTR_AVAILABLE_WATER = "available_water"
+ATTR_FIELD_CAPACITY_DEPTH = "field_capacity_depth"
+ATTR_PERMANENT_WILTING_POINT_DEPTH = "pwp_depth"
+ATTR_PLANT_AVAILABLE_WATER = "plant_available_water"
+ATTR_READILY_AVAILABLE_WATER = "readily_available_water"
+ATTR_REFILL_POINT = "replenishment_point"
+ATTR_MAXIMUM_RUNTIME_BEFORE_RUNOFF = "max_runtime"
+ATTR_LANDSCAPE_COEFFICIENT = "landscape_coefficient"
+
+# program.watering_plan[0].zone_forecasts attrs
+ATTR_LANDSCAPE_EVAPOTRANSPIRATION = "etc"
+ATTR_REFERENCE_EVAPOTRANSPIRATION = "eto"
+
+# calculated attrs
+ATTR_STANDARD_RUNTIME = "standard_runtime"
+ATTR_CURRENT_MOISTURE_BALANCE = "current_moisture_balance"
 
 
 def _parse_battery_level(battery_data: dict) -> int:
@@ -214,7 +246,7 @@ async def async_setup_entry(
                 )
                 sensors.append(BHyveSensor(coordinator, device, description))
 
-            # Add zone history sensors
+            # Add zone history and smart watering soil sensors
             all_zones = device.get("zones", [])
             for zone in all_zones:
                 # if the zone doesn't have a name, set it to the device's name if
@@ -239,6 +271,23 @@ async def async_setup_entry(
                         ),
                     )
                 )
+                if zone["smart_watering_enabled"]:
+                    sensors.append(
+                        BHyveSmartWateringZoneSensor(
+                            coordinator,
+                            device,
+                            zone,
+                            zone_name,
+                            SensorEntityDescription(
+                                key="smart_watering_zone",
+                                translation_key="smart_watering_zone",
+                                icon="mdi:water-percent",
+                                device_class=SensorDeviceClass.MOISTURE,
+                                entity_category=EntityCategory.DIAGNOSTIC,
+                                native_unit_of_measurement=PERCENTAGE,
+                            ),
+                        )
+                    )
 
             # Add battery sensor if device has battery
             if device.get("battery", None) is not None:
@@ -443,3 +492,255 @@ class BHyveZoneHistorySensor(BHyveCoordinatorEntity, SensorEntity):
             .get(self._device_id, {})
             .get("history", [])
         )
+
+
+class BHyveSmartWateringZoneSensor(BHyveCoordinatorEntity, SensorEntity):
+    # see https://husqvarna-water.com/smart-watering-101/ for formulas
+    """Define a BHyve smart watering zone sensor."""
+
+    entity_description: SensorEntityDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: BHyveDataUpdateCoordinator,
+        device: BHyveDevice,
+        zone: dict,
+        zone_name: str,
+        description: SensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        self.entity_description = description
+        if zone_name == device.get("name"):
+            self._attr_name = "Smart watering"
+        else:
+            self._attr_name = f"{zone_name} smart watering"
+        self._attr_translation_placeholders = {"zone_name": zone_name}
+        super().__init__(coordinator, device)
+
+        self._zone = zone
+        self._zone_id = zone.get("station")
+        self._attr_unique_id = (
+            f"{self._mac_address}:{self._device_id}:{self._zone_id}:smart_watering_zone"
+        )
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the state of the entity."""
+        landscape = self._get_landscape()
+        if not landscape:
+            return None
+        # B-hyve computed value for 0% moisture
+        landscape_moisture_level_0 = landscape["replenishment_point"]
+
+        # B-hyve computed value for 100% moisture
+        landscape_moisture_level_100 = landscape["field_capacity_depth"]
+
+        # B-hyve reported current moisture
+        landscape_moisture_level = self._get_current_moisture_balance()
+        if (
+            landscape_moisture_level_0 is None
+            or landscape_moisture_level_100 is None
+            or landscape_moisture_level is None
+        ):
+            return None
+
+        landscape_moisture_percentage = (
+            (landscape_moisture_level - landscape_moisture_level_0)
+            / (landscape_moisture_level_100 - landscape_moisture_level_0)
+        ) * 100
+
+        return max(0, min(100, round(landscape_moisture_percentage)))
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the device state attributes."""
+        landscape = self._get_landscape()
+        if not landscape:
+            return {}
+
+        zone_forcast = self._get_zone_forecast()
+        if not zone_forcast:
+            return {}
+
+        return {
+            # editable
+            ATTR_APPLICATION_RATE: landscape.get(ATTR_APPLICATION_RATE),
+            ATTR_EFFICIENCY: landscape.get(ATTR_EFFICIENCY),
+            ATTR_PLANT_FACTOR: landscape.get(ATTR_PLANT_FACTOR),
+            ATTR_MICROCLIMATE_FACTOR: landscape.get(ATTR_MICROCLIMATE_FACTOR),
+            ATTR_MGMT_ALLOWED_DEPLETION: landscape.get(ATTR_MGMT_ALLOWED_DEPLETION),
+            ATTR_FIELD_CAPACITY: landscape.get(ATTR_FIELD_CAPACITY),
+            ATTR_PERMANENT_WILTING_POINT: landscape.get(ATTR_PERMANENT_WILTING_POINT),
+            ATTR_ROOT_ZONE: landscape.get(ATTR_ROOT_ZONE),
+            ATTR_ALLOWABLE_SURFACE_ACCUMULATION: landscape.get(
+                ATTR_ALLOWABLE_SURFACE_ACCUMULATION
+            ),
+            ATTR_BASIC_INFILTRATION_RATE: landscape.get(ATTR_BASIC_INFILTRATION_RATE),
+            ATTR_EFFECTIVE_RAINFALL: landscape.get(ATTR_EFFECTIVE_RAINFALL),
+            ATTR_DROUGHT_FACTOR: landscape.get(ATTR_DROUGHT_FACTOR),
+            # computed
+            ATTR_AVAILABLE_WATER: landscape.get(ATTR_AVAILABLE_WATER),
+            ATTR_FIELD_CAPACITY_DEPTH: landscape.get(ATTR_FIELD_CAPACITY_DEPTH),
+            ATTR_PERMANENT_WILTING_POINT_DEPTH: landscape.get(
+                ATTR_PERMANENT_WILTING_POINT_DEPTH
+            ),
+            ATTR_PLANT_AVAILABLE_WATER: landscape.get(ATTR_PLANT_AVAILABLE_WATER),
+            ATTR_READILY_AVAILABLE_WATER: landscape.get(ATTR_READILY_AVAILABLE_WATER),
+            ATTR_REFILL_POINT: landscape.get(ATTR_REFILL_POINT),
+            ATTR_STANDARD_RUNTIME: self._get_standard_runtime_minutes(),
+            ATTR_MAXIMUM_RUNTIME_BEFORE_RUNOFF: landscape.get(
+                ATTR_MAXIMUM_RUNTIME_BEFORE_RUNOFF
+            ),
+            ATTR_REFERENCE_EVAPOTRANSPIRATION: zone_forcast.get(
+                ATTR_REFERENCE_EVAPOTRANSPIRATION
+            ),
+            ATTR_LANDSCAPE_COEFFICIENT: landscape.get(ATTR_LANDSCAPE_COEFFICIENT),
+            ATTR_LANDSCAPE_EVAPOTRANSPIRATION: zone_forcast.get(
+                ATTR_LANDSCAPE_EVAPOTRANSPIRATION
+            ),
+            ATTR_CURRENT_MOISTURE_BALANCE: self._get_current_moisture_balance(),
+        }
+
+    def _get_standard_runtime_minutes(self) -> int | None:
+        """Calculate standard runtime based on values from the landscape."""
+        landscape = self._get_landscape()
+        if not landscape:
+            return None
+
+        readily_available_water = landscape.get(ATTR_READILY_AVAILABLE_WATER)
+        application_rate = landscape.get(ATTR_APPLICATION_RATE)
+        efficiency = landscape.get(ATTR_EFFICIENCY)
+
+        if (
+            readily_available_water is None
+            or application_rate is None
+            or efficiency is None
+        ):
+            return None
+
+        standard_runtime_hours = (
+            readily_available_water / application_rate
+        ) / efficiency
+
+        return round(standard_runtime_hours * 60)
+
+    def _get_current_moisture_balance(self) -> float | None:
+        """Calculate current moisture balance based on values from the zone forecast."""
+        zone_forcast = self._get_zone_forecast()
+        if not zone_forcast:
+            return None
+
+        landscape = self._get_landscape()
+        if not landscape:
+            return None
+
+        initial_moisture_balance = zone_forcast.get("initial_water_level")
+
+        reference_evapotranspiration = zone_forcast.get(
+            ATTR_REFERENCE_EVAPOTRANSPIRATION
+        )
+        landscape_coefficient = landscape.get(ATTR_LANDSCAPE_COEFFICIENT)
+        if reference_evapotranspiration is None or landscape_coefficient is None:
+            return None
+
+        landscape_evapotranspiration = (
+            reference_evapotranspiration * landscape_coefficient
+        )
+
+        effective_rainfall = zone_forcast.get("effective_rainfall")
+
+        effective_irrigation = zone_forcast.get("effective_irrigation")
+
+        if (
+            initial_moisture_balance is None
+            or landscape_evapotranspiration is None
+            or effective_rainfall is None
+            or effective_irrigation is None
+        ):
+            return None
+
+        local_tz = dt.get_default_time_zone()
+
+        now = datetime.now(local_tz)
+
+        nine_am = now.replace(hour=9, minute=0, second=0, microsecond=0)
+
+        nine_pm = now.replace(hour=21, minute=0, second=0, microsecond=0)
+
+        current_moisture_balance: float | None
+        if now < nine_am:
+            current_moisture_balance = initial_moisture_balance
+        elif now < nine_pm:
+            daylight_hours_elapsed = (now - nine_am).total_seconds() / 3600
+            total_daylight_hours = 12
+            evapotranspiration_loss = landscape_evapotranspiration * (
+                daylight_hours_elapsed / total_daylight_hours
+            )
+            current_moisture_balance = (
+                initial_moisture_balance
+                - evapotranspiration_loss
+                + effective_rainfall
+                + effective_irrigation
+            )
+        else:
+            current_moisture_balance = zone_forcast.get("final_water_level")
+
+        return current_moisture_balance
+
+    def _get_landscape(self) -> dict | None:
+        """Return the landscape entry for this zone."""
+        landscapes = self._get_device_landscapes()
+        return landscapes.get(str(self._zone_id))
+
+    def _get_device_landscapes(self) -> dict:
+        """Get landscapes from coordinator."""
+        return (
+            self.coordinator.data.get("devices", {})
+            .get(self._device_id, {})
+            .get("landscapes", [])
+        )
+
+    def _get_zone_forecast(self) -> dict | None:
+        """Return the current day's watering forecast for this zone."""
+        smart_program = self._get_smart_watering_program()
+        if not smart_program:
+            return {}
+
+        watering_plan = smart_program.get("watering_plan")
+        if not watering_plan:
+            return {}
+
+        current_day_forecasts = watering_plan[0].get("zone_forecasts")
+        if not current_day_forecasts:
+            return {}
+
+        zone_forecast: dict | None = None
+        for forecast in current_day_forecasts:
+            if forecast.get("station") == self._zone_id:
+                zone_forecast = forecast
+                break
+
+        return zone_forecast
+
+    def _get_smart_watering_program(self) -> dict | None:
+        """Get smart watering program for this device."""
+        smart_program: dict | None = None
+
+        for program in self._get_programs().values():
+            if not program.get("is_smart_program"):
+                continue
+
+            device_id = program.get("device_id")
+            if not device_id:
+                continue
+
+            if device_id == self._device_id:
+                smart_program = program
+                break
+
+        return smart_program
+
+    def _get_programs(self) -> dict:
+        """Get programs from coordinator."""
+        return self.coordinator.data.get("programs", {})

--- a/custom_components/bhyve/sensor.py
+++ b/custom_components/bhyve/sensor.py
@@ -714,7 +714,17 @@ class BHyveSmartWateringZoneSensor(BHyveCoordinatorEntity, SensorEntity):
         if not watering_plan:
             return {}
 
-        current_day_forecasts = watering_plan[0].get("zone_forecasts")
+        current_date = self._get_local_datetime().date()
+        current_day_plan: dict | None = None
+        for daily_plan in watering_plan:
+            if datetime.fromisoformat(daily_plan["date"]).date() == current_date:
+                current_day_plan = daily_plan
+                break
+
+        if not current_day_plan:
+            return {}
+
+        current_day_forecasts = current_day_plan.get("zone_forecasts")
         if not current_day_forecasts:
             return {}
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,6 +1,6 @@
 """Test BHyve sensor entities."""
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -924,8 +924,6 @@ class TestBHyveSmartWateringZoneSensor:
             mock_smart_watering_programs_data,
         )
 
-        zone = {"station": 2, "name": "Front Lawn"}
-
         # Create description for the zone
         description = SensorEntityDescription(
             key="smart_watering_zone",
@@ -938,7 +936,7 @@ class TestBHyveSmartWateringZoneSensor:
         sensor = BHyveSmartWateringZoneSensor(
             coordinator=coordinator,
             device=mock_sprinkler_device_with_battery,
-            zone=zone,
+            zone={"station": 2, "name": "Front Lawn"},
             zone_name="Front Lawn",
             description=description,
         )
@@ -948,37 +946,36 @@ class TestBHyveSmartWateringZoneSensor:
             BHyveSmartWateringZoneSensor, "_get_local_datetime"
         ) as mock_get_local_datetime:
             mock_get_local_datetime.return_value = datetime(
-                2026, 8, 30, 2, 00, tzinfo=timezone.utc
+                2026, 8, 30, 2, 00, tzinfo=UTC
             )
-            assert sensor.native_value is not None
             assert sensor.native_value == 100
             assert (
                 sensor.extra_state_attributes["current_moisture_balance"]
                 == 2.5034046142773994 + 0.2 + 0.3
             )
 
-        # 9am - Test state based on initial water level plus rainfall and irrigation minus 0% evapotranspiration
+        # 9am - Test state based on initial water level plus rainfall and irrigation
+        # minus 0% evapotranspiration
         with patch.object(
             BHyveSmartWateringZoneSensor, "_get_local_datetime"
         ) as mock_get_local_datetime:
             mock_get_local_datetime.return_value = datetime(
-                2026, 8, 30, 9, 00, tzinfo=timezone.utc
+                2026, 8, 30, 9, 00, tzinfo=UTC
             )
-            assert sensor.native_value is not None
             assert sensor.native_value == 100
             assert (
                 sensor.extra_state_attributes["current_moisture_balance"]
                 == 2.5034046142773994 + 0.2 + 0.3
             )
 
-        # 3pm - Test state based on initial water level plus rainfall and irrigation minus 50% evapotranspiration
+        # 3pm - Test state based on initial water level plus rainfall and irrigation
+        # minus 50% evapotranspiration
         with patch.object(
             BHyveSmartWateringZoneSensor, "_get_local_datetime"
         ) as mock_get_local_datetime:
             mock_get_local_datetime.return_value = datetime(
-                2026, 8, 30, 15, 00, tzinfo=timezone.utc
+                2026, 8, 30, 15, 00, tzinfo=UTC
             )
-            assert sensor.native_value is not None
             assert sensor.native_value == 100
             assert sensor.extra_state_attributes[
                 "current_moisture_balance"
@@ -989,9 +986,8 @@ class TestBHyveSmartWateringZoneSensor:
             BHyveSmartWateringZoneSensor, "_get_local_datetime"
         ) as mock_get_local_datetime:
             mock_get_local_datetime.return_value = datetime(
-                2026, 8, 30, 22, 00, tzinfo=timezone.utc
+                2026, 8, 30, 22, 00, tzinfo=UTC
             )
-            assert sensor.native_value is not None
             assert sensor.native_value == 31
             assert (
                 sensor.extra_state_attributes["current_moisture_balance"]
@@ -1003,9 +999,8 @@ class TestBHyveSmartWateringZoneSensor:
             BHyveSmartWateringZoneSensor, "_get_local_datetime"
         ) as mock_get_local_datetime:
             mock_get_local_datetime.return_value = datetime(
-                2026, 8, 30, 22, 00, tzinfo=timezone.utc
+                2026, 8, 30, 22, 00, tzinfo=UTC
             )
-            assert sensor.native_value is not None
             assert sensor.native_value == 31
             assert (
                 sensor.extra_state_attributes["current_moisture_balance"]
@@ -1017,7 +1012,7 @@ class TestBHyveSmartWateringZoneSensor:
             BHyveSmartWateringZoneSensor, "_get_local_datetime"
         ) as mock_get_local_datetime:
             mock_get_local_datetime.return_value = datetime(
-                2026, 8, 30, 12, 00, tzinfo=timezone.utc
+                2026, 8, 30, 12, 00, tzinfo=UTC
             )
             attrs = sensor.extra_state_attributes
             assert attrs["application_rate"] == 0.5727296703296705

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -264,6 +264,37 @@ def mock_smart_watering_programs_data() -> dict:
             "process_at": "2026-08-31T14:18:00.000Z",
             "watering_plan": [
                 {
+                    "date": "2026-08-29T08:00:00.000Z",
+                    "start_times": [],
+                    "run_times": [],
+                    "zone_forecasts": [
+                        {
+                            "station": 2,
+                            "initial_water_level": 3.5034046142773994,
+                            "date": "2026-08-29T08:00:00.000Z",
+                            "eto": 0.29325470937656308,
+                            "mbo_raw": 0.35940461427739914,
+                            "net_irrigation": 0.0,
+                            "total_soak_runoff": 0,
+                            "total_direct_runoff": 0,
+                            "gross_irrigation": 0.0,
+                            "water_rule": "system_restricted",
+                            "rainfall": 0,
+                            "etc": 0.2546037675012505,
+                            "final_water_level": 2.5034046142773994,
+                            "delta": -1,
+                            "total_scheduling_losses": 0,
+                            "daily_surplus": 0,
+                            "device_id": "test-device-123",
+                            "soak_runoff": [],
+                            "mbf_raw": 0.20480084677614876,
+                            "effective_rainfall": 0.0,
+                            "effective_irrigation": 0.0,
+                            "direct_runoff": [],
+                        }
+                    ],
+                },
+                {
                     "date": "2026-08-30T08:00:00.000Z",
                     "start_times": [],
                     "run_times": [],
@@ -917,7 +948,7 @@ class TestBHyveSmartWateringZoneSensor:
             BHyveSmartWateringZoneSensor, "_get_local_datetime"
         ) as mock_get_local_datetime:
             mock_get_local_datetime.return_value = datetime(
-                2026, 5, 20, 2, 00, tzinfo=timezone.utc
+                2026, 8, 30, 2, 00, tzinfo=timezone.utc
             )
             assert sensor.native_value is not None
             assert sensor.native_value == 77
@@ -931,7 +962,7 @@ class TestBHyveSmartWateringZoneSensor:
             BHyveSmartWateringZoneSensor, "_get_local_datetime"
         ) as mock_get_local_datetime:
             mock_get_local_datetime.return_value = datetime(
-                2026, 5, 20, 9, 00, tzinfo=timezone.utc
+                2026, 8, 30, 9, 00, tzinfo=timezone.utc
             )
             assert sensor.native_value is not None
             assert sensor.native_value == 100
@@ -945,7 +976,7 @@ class TestBHyveSmartWateringZoneSensor:
             BHyveSmartWateringZoneSensor, "_get_local_datetime"
         ) as mock_get_local_datetime:
             mock_get_local_datetime.return_value = datetime(
-                2026, 5, 20, 15, 00, tzinfo=timezone.utc
+                2026, 8, 30, 15, 00, tzinfo=timezone.utc
             )
             assert sensor.native_value is not None
             assert sensor.native_value == 100
@@ -958,7 +989,7 @@ class TestBHyveSmartWateringZoneSensor:
             BHyveSmartWateringZoneSensor, "_get_local_datetime"
         ) as mock_get_local_datetime:
             mock_get_local_datetime.return_value = datetime(
-                2026, 5, 20, 22, 00, tzinfo=timezone.utc
+                2026, 8, 30, 22, 00, tzinfo=timezone.utc
             )
             assert sensor.native_value is not None
             assert sensor.native_value == 31
@@ -967,31 +998,37 @@ class TestBHyveSmartWateringZoneSensor:
                 == 2.348800846776149
             )
 
-        # Test attributes
-        attrs = sensor.extra_state_attributes
-        assert attrs["application_rate"] == 0.5727296703296705
-        assert attrs["efficiency"] == 0.5845321186787661
-        assert attrs["plant_factor"] == 0.8
-        assert attrs["micro_climate"] == 1
-        assert attrs["max_allowable_depletion"] == 0.35
-        assert attrs["field_capacity"] == 0.43
-        assert attrs["permanent_wilting_point"] == 0.27
-        assert attrs["root_depth"] == 6
-        assert attrs["allowable_soil_acc"] == 0.16
-        assert attrs["infiltration_rate"] == 0.15
-        assert attrs["rainfall_efficiency"] == 0.4
-        assert attrs["drought_factor"] == 1
-        assert attrs["available_water"] == 0.15999999999999998
-        assert attrs["field_capacity_depth"] == 2.58
-        assert attrs["pwp_depth"] == 1.62
-        assert attrs["plant_available_water"] == 0.96
-        assert attrs["readily_available_water"] == 0.33599999999999997
-        assert attrs["replenishment_point"] == 2.244
-        assert attrs["max_runtime"] == 22
-        assert attrs["landscape_coefficient"] == 0.8
-        assert attrs["etc"] == 0.1546037675012505
-        assert attrs["eto"] == 0.19325470937656308
-        assert attrs["standard_runtime"] == 60
+        # Test fixed attributes
+        with patch.object(
+            BHyveSmartWateringZoneSensor, "_get_local_datetime"
+        ) as mock_get_local_datetime:
+            mock_get_local_datetime.return_value = datetime(
+                2026, 8, 30, 12, 00, tzinfo=timezone.utc
+            )
+            attrs = sensor.extra_state_attributes
+            assert attrs["application_rate"] == 0.5727296703296705
+            assert attrs["efficiency"] == 0.5845321186787661
+            assert attrs["plant_factor"] == 0.8
+            assert attrs["micro_climate"] == 1
+            assert attrs["max_allowable_depletion"] == 0.35
+            assert attrs["field_capacity"] == 0.43
+            assert attrs["permanent_wilting_point"] == 0.27
+            assert attrs["root_depth"] == 6
+            assert attrs["allowable_soil_acc"] == 0.16
+            assert attrs["infiltration_rate"] == 0.15
+            assert attrs["rainfall_efficiency"] == 0.4
+            assert attrs["drought_factor"] == 1
+            assert attrs["available_water"] == 0.15999999999999998
+            assert attrs["field_capacity_depth"] == 2.58
+            assert attrs["pwp_depth"] == 1.62
+            assert attrs["plant_available_water"] == 0.96
+            assert attrs["readily_available_water"] == 0.33599999999999997
+            assert attrs["replenishment_point"] == 2.244
+            assert attrs["max_runtime"] == 22
+            assert attrs["landscape_coefficient"] == 0.8
+            assert attrs["etc"] == 0.1546037675012505
+            assert attrs["eto"] == 0.19325470937656308
+            assert attrs["standard_runtime"] == 60
 
 
 class TestSensorWebsocketEvents:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -943,7 +943,7 @@ class TestBHyveSmartWateringZoneSensor:
             description=description,
         )
 
-        # Test state based on initial water level
+        # Pre 9am - Test state based on initial water level plus rainfall and irrigation
         with patch.object(
             BHyveSmartWateringZoneSensor, "_get_local_datetime"
         ) as mock_get_local_datetime:
@@ -951,13 +951,13 @@ class TestBHyveSmartWateringZoneSensor:
                 2026, 8, 30, 2, 00, tzinfo=timezone.utc
             )
             assert sensor.native_value is not None
-            assert sensor.native_value == 77
+            assert sensor.native_value == 100
             assert (
                 sensor.extra_state_attributes["current_moisture_balance"]
-                == 2.5034046142773994
+                == 2.5034046142773994 + 0.2 + 0.3
             )
 
-        # Test state based on initial water level plus rainfall and irrigation
+        # 9am - Test state based on initial water level plus rainfall and irrigation minus 0% evapotranspiration
         with patch.object(
             BHyveSmartWateringZoneSensor, "_get_local_datetime"
         ) as mock_get_local_datetime:
@@ -971,7 +971,7 @@ class TestBHyveSmartWateringZoneSensor:
                 == 2.5034046142773994 + 0.2 + 0.3
             )
 
-        # Test state based on initial water level plus rainfall and irrigation minus one half evapotranspiration
+        # 3pm - Test state based on initial water level plus rainfall and irrigation minus 50% evapotranspiration
         with patch.object(
             BHyveSmartWateringZoneSensor, "_get_local_datetime"
         ) as mock_get_local_datetime:
@@ -984,7 +984,21 @@ class TestBHyveSmartWateringZoneSensor:
                 "current_moisture_balance"
             ] == 2.5034046142773994 + 0.2 + 0.3 - (0.19325470937656308 * 0.8 * 0.5)
 
-        # Test state based on final water level
+        # 9 pm - Test state based on final water level
+        with patch.object(
+            BHyveSmartWateringZoneSensor, "_get_local_datetime"
+        ) as mock_get_local_datetime:
+            mock_get_local_datetime.return_value = datetime(
+                2026, 8, 30, 22, 00, tzinfo=timezone.utc
+            )
+            assert sensor.native_value is not None
+            assert sensor.native_value == 31
+            assert (
+                sensor.extra_state_attributes["current_moisture_balance"]
+                == 2.348800846776149
+            )
+
+        # Post 9pm - Test state based on final water level
         with patch.object(
             BHyveSmartWateringZoneSensor, "_get_local_datetime"
         ) as mock_get_local_datetime:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -18,6 +18,7 @@ from custom_components.bhyve.sensor import (
     SENSOR_TYPES_SPRINKLER,
     BHyveSensor,
     BHyveSensorEntityDescription,
+    BHyveSmartWateringZoneSensor,
     BHyveZoneHistorySensor,
 )
 
@@ -27,12 +28,15 @@ TEST_BATTERY_LEVEL_UPDATED = 50
 TEST_TEMPERATURE_FAHRENHEIT = 72.5
 
 
-def create_mock_coordinator(devices: dict) -> MagicMock:
+def create_mock_coordinator(devices: dict, programs: dict | None = None) -> MagicMock:
     """Create a mock coordinator with the given devices."""
+    if programs is None:
+        programs = {}
+
     coordinator = MagicMock(spec=BHyveDataUpdateCoordinator)
     coordinator.data = {
         "devices": devices,
-        "programs": {},
+        "programs": programs,
     }
     coordinator.last_update_success = True
     coordinator.async_set_updated_data = MagicMock()
@@ -132,6 +136,235 @@ def mock_zone_history_data() -> list:
             ]
         }
     ]
+
+
+@pytest.fixture
+def mock_smart_watering_landscapes_data() -> dict:
+    """Mock smart watering landscapes data."""
+    return {
+        "1": {
+            "station": 1,
+            "root_depth": 12,
+            "max_allowable_depletion": 0.35,
+            "pwp_depth": 2.16,
+            "permanent_wilting_point": 0.18,
+            "allowable_soil_acc": 0.26,
+            "field_capacity_depth": 3.84,
+            "replenishment_point": 3.252,
+            "plant_available_water": 1.6799999999999997,
+            "max_runtime": 0,
+            "drought_factor": 1,
+            "micro_climate": 0.9,
+            "plant_factor": 0.7,
+            "available_water": 0.14,
+            "current_water_level": 3.252,
+            "application_rate": 31.857641025641016,
+            "field_capacity": 0.32,
+            "updated_at": "2026-08-20T18:00:00.000Z",
+            "distribution_uniformity": 0.8766692851531815,
+            "rainfall_efficiency": 0.63,
+            "min_water_level": 3.252,
+            "id": "a",
+            "landscape_coeffcient": 0.63,
+            "infiltration_rate": 0.2,
+            "monthly_eto": [
+                1.48273003101,
+                1.90748000145,
+                2.62103009224,
+                3.96890997887,
+                4.96686983109,
+                6.26438999176,
+                6.55533981323,
+                5.66915988922,
+                4.48599004745,
+                3.33847999573,
+                1.92864000797,
+                1.44123995304,
+            ],
+            "efficiency": 0.1356191102586882,
+            "device_id": "test-device-123",
+            "readily_available_water": 0.5879999999999999,
+            "created_at": "2026-08-19T18:00:00.000Z",
+            "scheduling_multiplier": 1.0799117746861213,
+        },
+        "2": {
+            "station": 2,
+            "root_depth": 6,
+            "max_allowable_depletion": 0.35,
+            "pwp_depth": 1.62,
+            "permanent_wilting_point": 0.27,
+            "allowable_soil_acc": 0.16,
+            "field_capacity_depth": 2.58,
+            "replenishment_point": 2.244,
+            "plant_available_water": 0.96,
+            "max_runtime": 22,
+            "drought_factor": 1,
+            "micro_climate": 1,
+            "plant_factor": 0.8,
+            "available_water": 0.15999999999999998,
+            "application_rate": 0.5727296703296705,
+            "field_capacity": 0.43,
+            "updated_at": "2026-08-20T18:00:00.000Z",
+            "distribution_uniformity": 0.7668539325842697,
+            "rainfall_efficiency": 0.4,
+            "min_water_level": 2.244,
+            "id": "b",
+            "landscape_coefficient": 0.8,
+            "infiltration_rate": 0.15,
+            "monthly_eto": [
+                1.48273003101,
+                1.90748000145,
+                2.62103009224,
+                3.96890997887,
+                4.96686983109,
+                6.26438999176,
+                6.55533981323,
+                5.66915988922,
+                4.48599004745,
+                3.33847999573,
+                1.92864000797,
+                1.44123995304,
+            ],
+            "efficiency": 0.5845321186787661,
+            "device_id": "test-device-123",
+            "readily_available_water": 0.33599999999999997,
+            "created_at": "2026-08-19T18:00:00.000Z",
+            "scheduling_multiplier": 1.1626387981711301,
+        },
+    }
+
+
+@pytest.fixture
+def mock_smart_watering_programs_data() -> dict:
+    """Mock smart watering programs data."""
+    return {
+        "a": {
+            "name": "Manual",
+            "program_start_date": "2026-08-18T06:00:00.000Z",
+            "frequency": {"type": "days", "days": [1, 3, 6]},
+            "program_end_date": None,
+            "updated_at": "2026-08-19T010:00:00.000Z",
+            "updated_via": "wifi",
+            "start_times": ["05:30", "07:00"],
+            "id": "a",
+            "budget": 100,
+            "is_smart_program": False,
+            "device_id": "test-device-123",
+            "program": "a",
+            "run_times": [{"run_time": 30, "station": 1}],
+            "enabled": True,
+            "created_at": "2026-08-17T012:00:00.000Z",
+        },
+        "b": {
+            "post_delay": 0.0,
+            "lock_at": "2026-08-31T08:00:00.000Z",
+            "name": "Smart Watering",
+            "frequency": {"type": "days", "days": [1, 3, 6]},
+            "process_at": "2026-08-31T14:18:00.000Z",
+            "watering_plan": [
+                {
+                    "date": "2026-08-30T08:00:00.000Z",
+                    "start_times": [],
+                    "run_times": [],
+                    "zone_forecasts": [
+                        {
+                            "station": 2,
+                            "initial_water_level": 2.5034046142773994,
+                            "date": "2026-08-30T08:00:00.000Z",
+                            "eto": 0.19325470937656308,
+                            "mbo_raw": 0.25940461427739914,
+                            "net_irrigation": 0.0,
+                            "total_soak_runoff": 0,
+                            "total_direct_runoff": 0,
+                            "gross_irrigation": 0.0,
+                            "water_rule": "system_restricted",
+                            "rainfall": 0,
+                            "etc": 0.1546037675012505,
+                            "final_water_level": 2.348800846776149,
+                            "delta": -0.15460376750125038,
+                            "total_scheduling_losses": 0,
+                            "daily_surplus": 0,
+                            "device_id": "test-device-123",
+                            "soak_runoff": [],
+                            "mbf_raw": 0.10480084677614876,
+                            "effective_rainfall": 0.2,
+                            "effective_irrigation": 0.3,
+                            "direct_runoff": [],
+                        }
+                    ],
+                },
+                {
+                    "date": "2026-08-31T08:00:00.000Z",
+                    "start_times": ["02:00", "03:15", "04:30"],
+                    "run_times": [
+                        {"station": 2, "run_time": 75, "device_id": "test-device-123"}
+                    ],
+                    "zone_forecasts": [
+                        {
+                            "station": 2,
+                            "initial_water_level": 2.348800846776149,
+                            "date": "2026-08-31T08:00:00.000Z",
+                            "eto": 0.1556276452562946,
+                            "mbo_raw": 0.10480084677614876,
+                            "net_irrigation": 0.3347788876279935,
+                            "total_soak_runoff": 0,
+                            "total_direct_runoff": 0,
+                            "gross_irrigation": 0.5727296703296705,
+                            "water_rule": "as-needed",
+                            "rainfall": 0,
+                            "etc": 0.12450211620503569,
+                            "final_water_level": 2.559077618199107,
+                            "delta": 0.05567300392170749,
+                            "total_scheduling_losses": 0,
+                            "daily_surplus": 0,
+                            "device_id": "test-device-123",
+                            "soak_runoff": [0, 0],
+                            "mbf_raw": 0.3150776181991066,
+                            "effective_rainfall": 0.0,
+                            "effective_irrigation": 0.0,
+                            "direct_runoff": [0, 0, 0],
+                        }
+                    ],
+                },
+            ],
+            "long_term_program": {
+                "frequency": {
+                    "type": "interval",
+                    "intervals": [9, 7, 5, 4, 3, 3, 2, 3, 3, 4, 7, 10],
+                },
+                "run_times": [{"run_time": 75, "station": 2}],
+                "group_run_times": [
+                    {
+                        "device_id": "test-device-123",
+                        "run_times": [{"run_time": 75, "station": 2}],
+                    }
+                ],
+                "start_times": ["02:00", "03:45", "05:30"],
+                "budgets": [0, 0, 0, 90, 80, 100, 80, 90, 80, 80, 0, 0],
+                "pre_delay": 0,
+                "post_delay": 0.0,
+            },
+            "group_id": "1",
+            "updated_at": "2026-08-30T21:00:00.000Z",
+            "pre_delay": 0,
+            "updated_via": "wifi",
+            "start_times": ["02:00", "03:15", "04:30"],
+            "id": "b",
+            "budget": 100,
+            "group_run_times": [
+                {
+                    "device_id": "test-device-123",
+                    "run_times": [{"run_time": 75, "station": 2}],
+                }
+            ],
+            "is_smart_program": True,
+            "device_id": "test-device-123",
+            "program": "e",
+            "run_times": [{"run_time": 75, "station": 2}],
+            "enabled": True,
+            "created_at": "2026-08-29T21:00:00.000Z",
+        },
+    }
 
 
 @pytest.fixture
@@ -596,6 +829,118 @@ class TestBHyveZoneHistorySensor:
         assert attrs["run_time"] == 0.97
         assert attrs["consumption_gallons"] == 2
         assert attrs["consumption_litres"] == 7.57
+
+
+class TestBHyveSmartWateringZoneSensor:
+    """Test BHyveSmartWateringZoneSensor entity."""
+
+    async def test_smart_watering_zone_sensor_initialization(
+        self,
+        mock_sprinkler_device_with_battery: BHyveDevice,
+    ) -> None:
+        """Test smart watering zone sensor entity initialization."""
+        coordinator = create_mock_coordinator(
+            {
+                "test-device-123": {
+                    "device": mock_sprinkler_device_with_battery,
+                    "history": [],
+                    "landscapes": {},
+                }
+            }
+        )
+
+        zone = {"station": "1", "name": "Front Lawn"}
+
+        # Create description for the zone
+        description = SensorEntityDescription(
+            key="smart_watering_zone",
+            translation_key="smart_watering_zone",
+            icon="mdi:water-percent",
+            device_class=SensorDeviceClass.MOISTURE,
+            entity_category=EntityCategory.DIAGNOSTIC,
+        )
+
+        sensor = BHyveSmartWateringZoneSensor(
+            coordinator=coordinator,
+            device=mock_sprinkler_device_with_battery,
+            zone=zone,
+            zone_name="Front Lawn",
+            description=description,
+        )
+
+        # Test basic properties
+        assert sensor._attr_name == "Front Lawn smart watering"
+        assert sensor._attr_translation_placeholders == {"zone_name": "Front Lawn"}
+        assert sensor.device_class == SensorDeviceClass.MOISTURE
+        assert sensor.entity_description.entity_category == EntityCategory.DIAGNOSTIC
+
+    async def test_smart_watering_zone_sensor_attributes(
+        self,
+        mock_sprinkler_device_with_battery: BHyveDevice,
+        mock_smart_watering_landscapes_data: dict,
+        mock_smart_watering_programs_data: dict,
+    ) -> None:
+        """Test smart watering zone sensor with landscape and zone forecast data."""
+        coordinator = create_mock_coordinator(
+            {
+                "test-device-123": {
+                    "device": mock_sprinkler_device_with_battery,
+                    "history": [],
+                    "landscapes": mock_smart_watering_landscapes_data,
+                }
+            },
+            mock_smart_watering_programs_data,
+        )
+
+        zone = {"station": 2, "name": "Front Lawn"}
+
+        # Create description for the zone
+        description = SensorEntityDescription(
+            key="smart_watering_zone",
+            translation_key="smart_watering_zone",
+            icon="mdi:water-percent",
+            device_class=SensorDeviceClass.MOISTURE,
+            entity_category=EntityCategory.DIAGNOSTIC,
+        )
+
+        sensor = BHyveSmartWateringZoneSensor(
+            coordinator=coordinator,
+            device=mock_sprinkler_device_with_battery,
+            zone=zone,
+            zone_name="Front Lawn",
+            description=description,
+        )
+
+        # Test state (should be a numeric value for MOISTURE device class)
+        assert sensor.native_value is not None
+        assert sensor.native_value == 77.20375424922597
+
+        # Test attributes
+        attrs = sensor.extra_state_attributes
+        assert attrs["application_rate"] == 0.5727296703296705
+        assert attrs["efficiency"] == 0.5845321186787661
+        assert attrs["plant_factor"] == 0.8
+        assert attrs["micro_climate"] == 1
+        assert attrs["max_allowable_depletion"] == 0.35
+        assert attrs["field_capacity"] == 0.43
+        assert attrs["permanent_wilting_point"] == 0.27
+        assert attrs["root_depth"] == 6
+        assert attrs["allowable_soil_acc"] == 0.16
+        assert attrs["infiltration_rate"] == 0.15
+        assert attrs["rainfall_efficiency"] == 0.4
+        assert attrs["drought_factor"] == 1
+        assert attrs["available_water"] == 0.15999999999999998
+        assert attrs["field_capacity_depth"] == 2.58
+        assert attrs["pwp_depth"] == 1.62
+        assert attrs["plant_available_water"] == 0.96
+        assert attrs["readily_available_water"] == 0.33599999999999997
+        assert attrs["replenishment_point"] == 2.244
+        assert attrs["max_runtime"] == 22
+        assert attrs["landscape_coefficient"] == 0.8
+        assert attrs["etc"] == 0.1546037675012505
+        assert attrs["eto"] == 0.19325470937656308
+        assert attrs["standard_runtime"] == 60
+        assert attrs["current_moisture_balance"] == 2.5034046142773994
 
 
 class TestSensorWebsocketEvents:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,6 +1,7 @@
 """Test BHyve sensor entities."""
 
-from unittest.mock import AsyncMock, MagicMock
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.components.sensor import (
@@ -911,9 +912,60 @@ class TestBHyveSmartWateringZoneSensor:
             description=description,
         )
 
-        # Test state (should be a numeric value for MOISTURE device class)
-        assert sensor.native_value is not None
-        assert sensor.native_value == 77.20375424922597
+        # Test state based on initial water level
+        with patch.object(
+            BHyveSmartWateringZoneSensor, "_get_local_datetime"
+        ) as mock_get_local_datetime:
+            mock_get_local_datetime.return_value = datetime(
+                2026, 5, 20, 2, 00, tzinfo=timezone.utc
+            )
+            assert sensor.native_value is not None
+            assert sensor.native_value == 77
+            assert (
+                sensor.extra_state_attributes["current_moisture_balance"]
+                == 2.5034046142773994
+            )
+
+        # Test state based on initial water level plus rainfall and irrigation
+        with patch.object(
+            BHyveSmartWateringZoneSensor, "_get_local_datetime"
+        ) as mock_get_local_datetime:
+            mock_get_local_datetime.return_value = datetime(
+                2026, 5, 20, 9, 00, tzinfo=timezone.utc
+            )
+            assert sensor.native_value is not None
+            assert sensor.native_value == 100
+            assert (
+                sensor.extra_state_attributes["current_moisture_balance"]
+                == 2.5034046142773994 + 0.2 + 0.3
+            )
+
+        # Test state based on initial water level plus rainfall and irrigation minus one half evapotranspiration
+        with patch.object(
+            BHyveSmartWateringZoneSensor, "_get_local_datetime"
+        ) as mock_get_local_datetime:
+            mock_get_local_datetime.return_value = datetime(
+                2026, 5, 20, 15, 00, tzinfo=timezone.utc
+            )
+            assert sensor.native_value is not None
+            assert sensor.native_value == 100
+            assert sensor.extra_state_attributes[
+                "current_moisture_balance"
+            ] == 2.5034046142773994 + 0.2 + 0.3 - (0.19325470937656308 * 0.8 * 0.5)
+
+        # Test state based on final water level
+        with patch.object(
+            BHyveSmartWateringZoneSensor, "_get_local_datetime"
+        ) as mock_get_local_datetime:
+            mock_get_local_datetime.return_value = datetime(
+                2026, 5, 20, 22, 00, tzinfo=timezone.utc
+            )
+            assert sensor.native_value is not None
+            assert sensor.native_value == 31
+            assert (
+                sensor.extra_state_attributes["current_moisture_balance"]
+                == 2.348800846776149
+            )
 
         # Test attributes
         attrs = sensor.extra_state_attributes
@@ -940,7 +992,6 @@ class TestBHyveSmartWateringZoneSensor:
         assert attrs["etc"] == 0.1546037675012505
         assert attrs["eto"] == 0.19325470937656308
         assert attrs["standard_runtime"] == 60
-        assert attrs["current_moisture_balance"] == 2.5034046142773994
 
 
 class TestSensorWebsocketEvents:


### PR DESCRIPTION
Adds a smart watering zone diagnostic sensor to every zone with smart watering enabled on a sprinkler device.  

The primary sensor value is the soil moisture percentage, which is not (as far as I can tell) returned through the API, so it needs to be calculated client side.  The value is calculated using the formula documented at https://husqvarna-water.com/smart-watering-101/, and I've manually verified that the calculated values match the values displayed in the official B-hyve app.

Other smart watering values that displayed in the B-hyve app under `Advanced Details` are exposed on the sensor as extra state attributes.

Fixes #133 